### PR TITLE
Fix: resolve npm publish error by removing hard links

### DIFF
--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -34,10 +34,6 @@ jobs:
     - run: npm install --only=dev --no-package-lock
       name: Install dev dependencies for the release
 
-    - name: Find and remove hard links
-      run: |
-        find . -type f -links +1 -exec sh -c 'cp -p "$0" "$0.tmp" && mv "$0.tmp" "$0"' {} \;
-
     - run: npx semantic-release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "prepare": "npm run build:addon && npm run build",
+    "prepublishOnly": "find build/Release -type f -links +1 -exec sh -c 'cp -p \"$0\" \"$0.tmp\" && mv \"$0.tmp\" \"$0\"' {} \\;",
     "test": "sudo npm run test:integration && npm run test:unit",
     "test:unit": "sudo npx mocha 'test/tuntap-unit.spec.mjs' --exit --timeout 2m",
     "test:integration": "sudo npx mocha 'test/tuntap-integration.spec.mjs' --exit --timeout 2m"


### PR DESCRIPTION
Moves the logic to remove hard links from the CI workflow into a `prepublishOnly` script in `package.json`

This prevents the 'E415 Unsupported Media Type - Hard link is not allowed' error during 'npm publish' by ensuring that any hard links created by 'node-gyp' during the build process are removed before the package is tarred and sent to the npm registry.