### PR TITLE
feat: Set minimum Node.js version to 20

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,16 +41,20 @@
   "license": "Apache-2.0",
   "gypfile": true,
   "dependencies": {
-    "@appium/support": "^6.0.0",
+    "@appium/support": "^7.0.0-rc.1",
     "node-addon-api": "^8.5.0",
     "typescript": "^5.8.3"
   },
   "devDependencies": {
-    "@appium/eslint-config-appium-ts": "^1.0.0",
+    "@appium/eslint-config-appium-ts": "^2.0.0-rc.1",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
     "@types/node": "^24.1.0",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "semantic-release": "^24.0.0"
+  },
+  "engines": {
+    "node": "^20.19.0 || ^22.12.0 || >=24.0.0",
+    "npm": ">=10"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Required Node.js version has been bumped to ^20.19.0 || ^22.12.0 || >=24.0.0
BREAKING CHANGE: Required npm version has been bumped to >=10