### PR TITLE
refactor: remove global signal handlers from library code

### DIFF
--- a/src/TunTap.ts
+++ b/src/TunTap.ts
@@ -81,6 +81,7 @@ export class TunTap {
         this.isOpen = false;
         this.isClosed = false;
 
+        // Register cleanup on process exit
         const cleanup = () => {
             if (this.isOpen && !this.isClosed) {
                 try {

--- a/src/TunTap.ts
+++ b/src/TunTap.ts
@@ -74,7 +74,7 @@ export class TunTap {
     private device: any;
     private isOpen: boolean;
     private isClosed: boolean;
-    private cleanupHandler: (() => void) | null = null;
+    private removeExitListener: (() => void) | null = null;
 
     constructor(name: string = '') {
         this.device = new nativeTuntap.TunDevice(name);
@@ -94,7 +94,7 @@ export class TunTap {
 
         process.once('exit', cleanup);
 
-        this.cleanupHandler = () => {
+        this.removeExitListener = () => {
             process.removeListener('exit', cleanup);
         };
     }
@@ -124,9 +124,9 @@ export class TunTap {
     }
 
     close(): boolean {
-        if (this.cleanupHandler) {
-            this.cleanupHandler();
-            this.cleanupHandler = null;
+        if (this.removeExitListener) {
+            this.removeExitListener();
+            this.removeExitListener = null;
         }
 
         if (!this.isClosed) {

--- a/src/TunTap.ts
+++ b/src/TunTap.ts
@@ -74,14 +74,13 @@ export class TunTap {
     private device: any;
     private isOpen: boolean;
     private isClosed: boolean;
-    private cleanupHandlers: (() => void)[] = [];
+    private cleanupHandler: (() => void) | null = null;
 
     constructor(name: string = '') {
         this.device = new nativeTuntap.TunDevice(name);
         this.isOpen = false;
         this.isClosed = false;
 
-        // Register cleanup on process exit
         const cleanup = () => {
             if (this.isOpen && !this.isClosed) {
                 try {
@@ -93,14 +92,10 @@ export class TunTap {
         };
 
         process.once('exit', cleanup);
-        process.once('SIGINT', cleanup);
-        process.once('SIGTERM', cleanup);
 
-        this.cleanupHandlers.push(() => {
+        this.cleanupHandler = () => {
             process.removeListener('exit', cleanup);
-            process.removeListener('SIGINT', cleanup);
-            process.removeListener('SIGTERM', cleanup);
-        });
+        };
     }
 
     open(): boolean {
@@ -128,6 +123,11 @@ export class TunTap {
     }
 
     close(): boolean {
+        if (this.cleanupHandler) {
+            this.cleanupHandler();
+            this.cleanupHandler = null;
+        }
+
         if (!this.isClosed) {
             try {
                 if (this.isOpen) {
@@ -135,10 +135,6 @@ export class TunTap {
                     this.isOpen = false;
                 }
                 this.isClosed = true;
-
-                // Run cleanup handlers
-                this.cleanupHandlers.forEach((handler) => handler());
-                this.cleanupHandlers = [];
             } catch (err: any) {
                 throw new TunTapError(`Failed to close device: ${err.message}`);
             }

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -38,50 +38,6 @@ export interface TunnelConnection {
     getPacketStream(): AsyncIterable<PacketData>;
 }
 
-// Global registry for active tunnel managers
-const activeTunnelManagers = new Set<TunnelManager>();
-
-// Setup process signal handlers
-let signalHandlersSetup = false;
-function setupSignalHandlers() {
-    if (signalHandlersSetup) {return;}
-    signalHandlersSetup = true;
-
-    const gracefulShutdown = async (signal: string) => {
-        log.debug(`Received ${signal}, initiating graceful shutdown...`);
-
-        // Copy the set to avoid modification during iteration
-        const managers = Array.from(activeTunnelManagers);
-
-        // Stop all tunnel managers
-        await Promise.all(managers.map((manager) => {
-            try {
-                return manager.stop();
-            } catch (err) {
-                log.error('Error stopping tunnel manager:', err);
-            }
-        }));
-
-        log.debug('All tunnel managers stopped, exiting...');
-        process.exit(0);
-    };
-
-    process.on('SIGINT', () => gracefulShutdown('SIGINT'));
-    process.on('SIGTERM', () => gracefulShutdown('SIGTERM'));
-
-    // Handle uncaught exceptions
-    process.on('uncaughtException', async (err) => {
-        log.error('Uncaught exception:', err);
-        await gracefulShutdown('uncaughtException');
-        process.exit(1);
-    });
-
-    // Handle unhandled promise rejections
-    process.on('unhandledRejection', (reason, promise) => {
-        log.error(`Unhandled rejection at: ${promise} reason: ${reason}`);
-    });
-}
-
 export class TunnelManager extends EventEmitter {
     private tun: TunTap | null;
     private cancelled: boolean;
@@ -102,12 +58,6 @@ export class TunnelManager extends EventEmitter {
         this.packetQueue = [];
         this.deviceConn = null;
         this.cleanupPromise = null;
-
-        // Setup signal handlers on first tunnel manager creation
-        setupSignalHandlers();
-
-        // Register this manager
-        activeTunnelManagers.add(this);
     }
 
     addPacketConsumer(consumer: PacketConsumer): void {
@@ -437,9 +387,6 @@ export class TunnelManager extends EventEmitter {
             }
             this.tun = null;
         }
-
-        // Unregister from active managers
-        activeTunnelManagers.delete(this);
 
         log.debug(`Tunnel for ${tunName} closed successfully`);
     }


### PR DESCRIPTION
- Remove SIGINT/SIGTERM listeners from TunTap constructor,libraries. should not install global signal handlers that call process.exit()
- Remove activeTunnelManagers global registry and setupSignalHandlers() from TunnelManager, including uncaughtException/unhandledRejection handlers
- Replace cleanupHandlers array with single cleanupHandler
- Move cleanupHandler invocation before device close to prevent exit  listener leak when native close throws