### PR TITLE
refactor: isolate OS networking in TunTapPlatform

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,49 +21,73 @@ npm run build
 npm run lint
 npm run lint:fix
 
-# Run all tests (unit + integration; integration requires root)
-sudo npm test
+# Tests (unit + integration; scripts invoke sudo for mocha on macOS/Linux)
+npm test
 
-# Run a specific test suite (most do not require root)
-npm run test:security
-npm run test:tunnel-manager
-npm run test:packet-stream
-npm run test:cdtunnel-protocol
-npm run test:buffer-handling
-npm run test:ipv6-format
+# Unit or integration only
+npm run test:unit
+npm run test:integration
 
-# Run a single test file directly
-npx mocha 'test/security.spec.mjs' --exit --timeout 30s
+# Ad-hoc: run mocha on a single file (add sudo if the test needs root)
+sudo npx mocha 'test/tuntap-unit.spec.mjs' --exit --timeout 2m
+```
 
-# Unit and integration tests (require root on macOS/Linux)
-sudo npm run test:unit
-sudo npm run test:integration
+## Project structure
+
+```
+src/
+  tuntap.cc              # C++ NAPI addon (built to build/Release/tuntap.node)
+  index.ts               # Package entry: TunTap, PacketCallback, errors, tunnel/*
+  TunTap.ts              # Wraps native TunDevice; validation; delegates OS networking to platform layer
+  tunnel.ts              # CDTunnel protocol, TunnelManager, connectToTunnelLockdown
+  logger.ts              # @appium/support logger
+  errors.ts              # TunTapError, TunTapPermissionError, TunTapDeviceError
+  platform/
+    types.ts             # TunTapPlatform interface, TunTapInterfaceStats
+    create-platform.ts   # Internal: maps NodeJS.Platform → platform implementation (not public API)
+    darwin.ts            # ifconfig, route, netstat (macOS)
+    linux.ts             # iproute2 `ip` (Linux)
+    unsupported.ts       # Stub that throws for unknown platforms
+    exec.ts              # promisify(execFile)
+    require-root.ts      # assertEffectiveRoot() — EUID 0 before privileged commands
+
+test/
+  tuntap-unit.spec.mjs
+  tuntap-integration.spec.mjs
+  test-tuntap.mjs
+  utils.mjs
+  check-linux-prereqs.sh
 ```
 
 ## Architecture
 
 This is a Node.js native addon package that provides TUN/TAP virtual network device support for Appium iOS tunneling. It has two layers:
 
-### Native Layer (`src/tuntap.cc`)
+### Native layer (`src/tuntap.cc`)
+
 A C++17 Node-API (NAPI) addon built via `node-gyp`. It exposes a single `TunDevice` class with `open()`, `close()`, `read()`, `write()`, `startPolling()`, `getName()`, and `getFd()`. Platform-specific code is conditional: macOS uses `utun` (kernel control socket via `UTUN_CONTROL_NAME`), Linux uses `/dev/net/tun` with `IFF_TUN`. The `startPolling` method uses a libuv poll handle (`uv_poll_t`) to drive event-based reads from the native thread pool rather than blocking JS.
 
-### TypeScript Layer (`src/`)
-- **`TunTap.ts`** — wraps the native addon, adds validation (IPv6, MTU range, buffer size), custom error types (`TunTapError`, `TunTapPermissionError`, `TunTapDeviceError`), and async helpers that shell out to `ifconfig`/`route` (macOS) or `ip` (Linux) via `execFile` with `sudo`.
-- **`tunnel.ts`** — implements the CDTunnel protocol used by iOS CoreDevice tunneling. `exchangeCoreTunnelParameters` performs a JSON handshake over a `CDTunnel`-framed TCP socket (8-byte magic + 2-byte length). `TunnelManager` (extends `EventEmitter`) bridges the Socket ↔ TUN device bidirectionally, parses IPv6 packets from the stream, and dispatches `PacketData` (TCP/UDP) to registered consumers or async iterators. `connectToTunnelLockdown` orchestrates handshake → interface setup → forwarding start.
-- **`logger.ts`** — thin wrapper around `@appium/support` logger.
-- **`index.ts`** — re-exports `TunTap` and everything from `tunnel.ts`.
+### TypeScript layer (`src/`)
 
-### Build Output
+- **`errors.ts`** — shared error classes used by `TunTap` and `platform/*`.
+- **`TunTap.ts`** — loads the native addon via `createRequire`, validates IPv6/MTU/buffers, and calls a **`TunTapPlatform`** instance chosen by **`new TunTap(name?, platform?)`** where `platform` is a **`NodeJS.Platform`** string (default `process.platform`). No custom platform object is accepted at runtime; new OS support is wired in **`platform/create-platform.ts`**.
+- **`platform/*`** — OS-specific **`execFile`** usage for address, MTU, routes, and stats. Built-in Darwin/Linux paths require **effective UID 0** (**`assertEffectiveRoot`**); commands are run **without** embedding `sudo` in argv. **`getStats`** uses read-only tooling where possible without an extra root check.
+- **`tunnel.ts`** — CDTunnel handshake (`exchangeCoreTunnelParameters`), **`TunnelManager`** (typed **`TunnelManagerEvents`** / `data` → **`PacketData`**), and **`connectToTunnelLockdown`**.
+- **`logger.ts`** — thin wrapper around `@appium/support` logger.
+- **`index.ts`** — re-exports **`TunTap`**, **`PacketCallback`**, errors from **`errors.ts`**, and **`export *`** from **`tunnel.ts`**. Does **not** export the platform factory or concrete platform classes.
+
+### Build output
+
 - `build/Release/tuntap.node` — compiled native addon (loaded at runtime via `createRequire`)
 - `lib/` — compiled TypeScript output; `lib/index.js` is the package entry point
 
-### Test Structure
-Tests in `test/` are `.mjs` ES module files using Mocha:
-- `security.spec.mjs`, `buffer-handling.spec.mjs`, `ipv6-format.spec.mjs`, `packet-stream.spec.mjs`, `cdtunnel-protocol.spec.mjs`, `tunnel-manager.spec.mjs` — pure logic tests, no root required; use `createMockSocket()` from `test/utils.mjs`
-- `tuntap-unit.spec.mjs`, `tuntap-integration.spec.mjs` — require root; tests that detect non-root will skip themselves
+### Tests
 
-### Key Constraints
-- Only IPv6 is supported (all addresses, routes, and packet parsing are IPv6-only)
-- `configure()` and route methods shell out with `sudo` — the caller must ensure sudo access
-- Signal handling (`SIGINT`/`SIGTERM`) is intentionally left to the caller; `TunTap` only registers a `process.once('exit')` cleanup handler
-- The native `startPolling` is one-shot per device; stopping is done by closing the TUN fd
+Mocha **`.mjs`** ES modules under **`test/`**. **`tuntap-unit.spec.mjs`** and **`tuntap-integration.spec.mjs`** expect **root** (scripts use `sudo`). Running as non-root may skip or fail depending on the case.
+
+### Key constraints
+
+- Only **IPv6** is supported (addresses, routes, packet parsing).
+- **`configure()`**, **`addRoute()`**, and **`removeRoute()`** on built-in platforms require the process to run as **root (EUID 0)**.
+- Signal handling (`SIGINT`/`SIGTERM`) is left to the caller; `TunTap` registers **`process.once('exit')`** cleanup only.
+- Native **`startPolling`** is one-shot per device; stopping is done by closing the TUN fd.

--- a/src/TunTap.ts
+++ b/src/TunTap.ts
@@ -10,12 +10,6 @@ import { log } from './logger.js';
 import { createTunTapPlatform } from './platform/create-platform.js';
 import type { TunTapInterfaceStats, TunTapPlatform } from './platform/types.js';
 
-export {
-    TunTapDeviceError,
-    TunTapError,
-    TunTapPermissionError,
-} from './errors.js';
-
 const require = createRequire(import.meta.url);
 const DEFAULT_READ_BUFFER_SIZE = 4096;
 const MAX_BUFFER_SIZE = 0xFFFF; // 65535

--- a/src/TunTap.ts
+++ b/src/TunTap.ts
@@ -1,18 +1,32 @@
-import { execFile } from 'node:child_process';
 import { createRequire } from 'node:module';
 import { isIPv6 } from 'node:net';
-import { promisify } from 'node:util';
 
+import {
+    TunTapDeviceError,
+    TunTapError,
+    TunTapPermissionError,
+} from './errors.js';
 import { log } from './logger.js';
+import { createTunTapPlatform } from './platform/create-platform.js';
+import type { TunTapInterfaceStats, TunTapPlatform } from './platform/types.js';
+
+export {
+    TunTapDeviceError,
+    TunTapError,
+    TunTapPermissionError,
+} from './errors.js';
 
 const require = createRequire(import.meta.url);
-const execFileAsync = promisify(execFile);
-const PLATFORM = process.platform;
 const DEFAULT_READ_BUFFER_SIZE = 4096;
 const MAX_BUFFER_SIZE = 0xFFFF; // 65535
 const DEFAULT_MTU = 1500;
 const MIN_MTU = 1280;
 
+/**
+ * Called by {@link TunTap.startPolling} for each packet read from the TUN device.
+ *
+ * @param data — raw L3 frame (IPv6) read from the device
+ */
 export type PacketCallback = (data: Buffer) => void;
 
 interface NativeTunDevice {
@@ -31,28 +45,6 @@ interface NativeTuntapModule {
 
 const nativeTuntap = require('../build/Release/tuntap.node') as NativeTuntapModule;
 
-// Custom error types
-export class TunTapError extends Error {
-    constructor(message: string, public code?: string) {
-        super(message);
-        this.name = 'TunTapError';
-    }
-}
-
-export class TunTapPermissionError extends TunTapError {
-    constructor(message: string) {
-        super(message, 'EPERM');
-        this.name = 'TunTapPermissionError';
-    }
-}
-
-export class TunTapDeviceError extends TunTapError {
-    constructor(message: string) {
-        super(message, 'ENODEV');
-        this.name = 'TunTapDeviceError';
-    }
-}
-
 /**
  * Validates an IPv6 route destination (address with optional CIDR prefix).
  */
@@ -67,16 +59,24 @@ function isValidIPv6Route(destination: string): boolean {
 }
 
 /**
- * TUN/TAP device for IP tunneling
+ * High-level wrapper around the native TUN device with IPv6-only configuration helpers.
+ *
+ * Routing and addressing use a built-in OS backend chosen from the `platform` argument (requires root, EUID 0 on Darwin/Linux).
  */
 export class TunTap {
     private device: NativeTunDevice;
+    private readonly platformBackend: TunTapPlatform;
     private _isOpen: boolean;
     private _isClosed: boolean;
     private removeExitListener: (() => void) | null = null;
 
-    constructor(name: string = '') {
+    /**
+     * @param name — optional interface name hint for the native layer
+     * @param platform — Node.js platform id (e.g. `darwin`, `linux`); defaults to `process.platform`
+     */
+    constructor(name: string = '', platform: NodeJS.Platform = process.platform) {
         this.device = new nativeTuntap.TunDevice(name);
+        this.platformBackend = createTunTapPlatform(platform);
         this._isOpen = false;
         this._isClosed = false;
 
@@ -99,26 +99,24 @@ export class TunTap {
         };
     }
 
+    /** Whether {@link TunTap.open} has succeeded and {@link TunTap.close} has not run. */
     get isOpen(): boolean {
         return this._isOpen;
     }
 
+    /** Whether {@link TunTap.close} has been called (device cannot be reopened). */
     get isClosed(): boolean {
         return this._isClosed;
     }
 
     /**
-     * Throws if the device is not in a usable state (not open or already closed).
+     * Open the TUN device via the native addon.
+     *
+     * @returns `true` when the device is open
+     * @throws {TunTapError} if already closed
+     * @throws {TunTapDeviceError} if the device cannot be opened
+     * @throws {TunTapPermissionError} if the OS denies access
      */
-    private assertReady(): void {
-        if (!this._isOpen) {
-            throw new TunTapError('Device not open');
-        }
-        if (this._isClosed) {
-            throw new TunTapError('Device has been closed');
-        }
-    }
-
     open(): boolean {
         if (this._isClosed) {
             throw new TunTapError('Device has been closed and cannot be reopened');
@@ -144,6 +142,12 @@ export class TunTap {
         return this._isOpen;
     }
 
+    /**
+     * Close the device and unregister process `exit` cleanup.
+     *
+     * @returns `true` when closed (idempotent)
+     * @throws {TunTapError} on native close failure
+     */
     close(): boolean {
         if (this.removeExitListener) {
             this.removeExitListener();
@@ -164,6 +168,14 @@ export class TunTap {
         return true;
     }
 
+    /**
+     * Read one datagram/packet from the TUN device (blocking in the native layer).
+     *
+     * @param maxSize — upper bound on bytes to read (default 4096)
+     * @returns packet buffer
+     * @throws {TunTapError} if not open, closed, or read fails
+     * @throws {RangeError} if `maxSize` is out of range
+     */
     read(maxSize: number = DEFAULT_READ_BUFFER_SIZE): Buffer {
         this.assertReady();
         if (maxSize <= 0 || maxSize > MAX_BUFFER_SIZE) {
@@ -177,6 +189,15 @@ export class TunTap {
         }
     }
 
+    /**
+     * Write a full IPv6 packet to the TUN device.
+     *
+     * @param data — L3 payload to write
+     * @returns number of bytes written
+     * @throws {TunTapError} if not open, closed, or write fails
+     * @throws {TypeError} if `data` is not a `Buffer`
+     * @throws {RangeError} if `data` exceeds the maximum buffer size
+     */
     write(data: Buffer): number {
         this.assertReady();
         if (!Buffer.isBuffer(data)) {
@@ -201,8 +222,13 @@ export class TunTap {
     }
 
     /**
-     * Start event-driven reading from the TUN device.
-     * The callback is invoked with each packet read from the device.
+     * Start libuv-driven polling on the TUN fd; `callback` runs on the Node thread pool per packet.
+     *
+     * @param callback — invoked with each packet read from the device
+     * @param bufferSize — max read size per poll (default 65535)
+     * @throws {TunTapError} if not open or closed
+     * @throws {TypeError} if `callback` is not a function
+     * @throws {RangeError} if `bufferSize` is out of range
      */
     startPolling(callback: PacketCallback, bufferSize: number = MAX_BUFFER_SIZE): void {
         this.assertReady();
@@ -215,14 +241,25 @@ export class TunTap {
         this.device.startPolling(callback, bufferSize);
     }
 
+    /** OS-assigned interface name (e.g. `utun4` on macOS). */
     get name(): string {
         return this.device.getName();
     }
 
+    /** File descriptor for the open TUN device (for advanced use). */
     get fd(): number {
         return this.device.getFd();
     }
 
+    /**
+     * Configure IPv6 address and MTU on this interface using the platform backend (must run as root on Darwin/Linux).
+     *
+     * @param address — IPv6 address
+     * @param mtu — link MTU (min 1280, max 65535)
+     * @throws {TypeError} if `address` is not a valid IPv6 literal
+     * @throws {RangeError} if `mtu` is out of range
+     * @throws {TunTapError} on backend failure
+     */
     async configure(address: string, mtu: number = DEFAULT_MTU): Promise<void> {
         this.assertReady();
         if (!isIPv6(address)) {
@@ -233,47 +270,20 @@ export class TunTap {
         }
 
         try {
-            if (PLATFORM === 'darwin') {
-                await execFileAsync('sudo', ['ifconfig', this.name, 'inet6', address, 'prefixlen', '64', 'up']);
-                await execFileAsync('sudo', ['ifconfig', this.name, 'mtu', String(mtu)]);
-            } else if (PLATFORM === 'linux') {
-                await this.configureLinux(address, mtu);
-            } else {
-                throw new TunTapError(`Unsupported platform: ${PLATFORM}`);
-            }
+            await this.platformBackend.configure(this.name, address, mtu);
         } catch (err: unknown) {
             if (err instanceof TunTapError) {throw err;}
             throw new TunTapError(`Failed to configure TUN interface: ${(err as Error).message}`);
         }
     }
 
-    private async configureLinux(address: string, mtu: number): Promise<void> {
-        try {
-            await execFileAsync('which', ['ip']);
-        } catch {
-            throw new TunTapError(
-                'The "ip" command is not available. Please install iproute2 (e.g., sudo apt install iproute2)',
-            );
-        }
-
-        try {
-            await execFileAsync('sudo', ['ip', '-6', 'addr', 'add', `${address}/64`, 'dev', this.name]);
-        } catch (err: unknown) {
-            const message = (err as Error).message;
-            if (message.includes('Permission denied')) {
-                throw new TunTapPermissionError(
-                    'Permission denied when configuring network interface. Run with sudo.',
-                );
-            }
-            if (!message.includes('File exists')) {
-                throw err;
-            }
-            log.warn(`Address ${address} may already be configured on ${this.name}`);
-        }
-
-        await execFileAsync('sudo', ['ip', 'link', 'set', 'dev', this.name, 'up', 'mtu', String(mtu)]);
-    }
-
+    /**
+     * Add an IPv6 route via this TUN interface.
+     *
+     * @param destination — IPv6 address or CIDR (e.g. `fd00::/64`)
+     * @throws {TypeError} if `destination` is invalid
+     * @throws {TunTapError} on backend failure
+     */
     async addRoute(destination: string): Promise<void> {
         this.assertReady();
         if (!destination || typeof destination !== 'string') {
@@ -284,35 +294,20 @@ export class TunTap {
         }
 
         try {
-            if (PLATFORM === 'darwin') {
-                await execFileAsync('sudo', ['route', '-n', 'add', '-inet6', destination, '-interface', this.name]);
-            } else if (PLATFORM === 'linux') {
-                await this.addRouteLinux(destination);
-            } else {
-                throw new TunTapError(`Unsupported platform: ${PLATFORM}`);
-            }
+            await this.platformBackend.addRoute(this.name, destination);
         } catch (err: unknown) {
             if (err instanceof TunTapError) {throw err;}
             throw new TunTapError(`Failed to add route: ${(err as Error).message}`);
         }
     }
 
-    private async addRouteLinux(destination: string): Promise<void> {
-        try {
-            await execFileAsync('sudo', ['ip', '-6', 'route', 'add', destination, 'dev', this.name]);
-        } catch (err: unknown) {
-            const message = (err as Error).message;
-            if (message.includes('Permission denied')) {
-                throw new TunTapPermissionError('Permission denied when adding route. Run with sudo.');
-            }
-            if (message.includes('File exists')) {
-                log.info(`Route to ${destination} already exists`);
-                return;
-            }
-            throw err;
-        }
-    }
-
+    /**
+     * Remove an IPv6 route previously added for this interface.
+     *
+     * @param destination — same form as {@link TunTap.addRoute}
+     * @throws {TypeError} if `destination` is invalid
+     * @throws {TunTapError} if the backend reports an error other than “route missing”
+     */
     async removeRoute(destination: string): Promise<void> {
         this.assertReady();
         if (!destination || typeof destination !== 'string') {
@@ -323,13 +318,7 @@ export class TunTap {
         }
 
         try {
-            if (PLATFORM === 'darwin') {
-                await execFileAsync('sudo', ['route', '-n', 'delete', '-inet6', destination]);
-            } else if (PLATFORM === 'linux') {
-                await execFileAsync('sudo', ['ip', '-6', 'route', 'del', destination, 'dev', this.name]);
-            } else {
-                throw new TunTapError(`Unsupported platform: ${PLATFORM}`);
-            }
+            await this.platformBackend.removeRoute(this.name, destination);
         } catch (err: unknown) {
             const message = (err as Error).message;
             if (message.includes('not in table') || message.includes('No such process')) {
@@ -340,80 +329,31 @@ export class TunTap {
     }
 
     /**
-     * Get interface statistics.
+     * Fetch RX/TX counters for this interface from the OS (e.g. `netstat` / `ip -s`).
+     *
+     * @returns byte and packet counts plus error counters
+     * @throws {TunTapError} if not ready or stats cannot be parsed
      */
-    async getStats(): Promise<{
-        rxBytes: number;
-        txBytes: number;
-        rxPackets: number;
-        txPackets: number;
-        rxErrors: number;
-        txErrors: number;
-    }> {
+    async getStats(): Promise<TunTapInterfaceStats> {
         this.assertReady();
 
         try {
-            if (PLATFORM === 'darwin') {
-                return await this.getStatsDarwin();
-            }
-            if (PLATFORM === 'linux') {
-                return await this.getStatsLinux();
-            }
-            throw new TunTapError(`Unsupported platform: ${PLATFORM}`);
+            return await this.platformBackend.getStats(this.name);
         } catch (err: unknown) {
             if (err instanceof TunTapError) {throw err;}
             throw new TunTapError(`Failed to get interface statistics: ${(err as Error).message}`);
         }
     }
 
-    private async getStatsDarwin() {
-        const { stdout } = await execFileAsync('netstat', ['-I', this.name, '-b']);
-        const lines = stdout.trim().split('\n');
-        if (lines.length < 2) {
-            throw new TunTapError('Unexpected netstat output');
+    /**
+     * Throws if the device is not in a usable state (not open or already closed).
+     */
+    private assertReady(): void {
+        if (!this._isOpen) {
+            throw new TunTapError('Device not open');
         }
-
-        const stats = lines[1].split(/\s+/);
-        return {
-            rxPackets: parseInt(stats[4], 10) || 0,
-            rxErrors: parseInt(stats[5], 10) || 0,
-            rxBytes: parseInt(stats[6], 10) || 0,
-            txPackets: parseInt(stats[7], 10) || 0,
-            txErrors: parseInt(stats[8], 10) || 0,
-            txBytes: parseInt(stats[9], 10) || 0,
-        };
-    }
-
-    private async getStatsLinux() {
-        const { stdout } = await execFileAsync('ip', ['-s', 'link', 'show', this.name]);
-        const lines = stdout.trim().split('\n');
-
-        const rxIndex = lines.findIndex((line) => line.includes('RX:'));
-        const txIndex = lines.findIndex((line) => line.includes('TX:'));
-
-        if (rxIndex === -1 || txIndex === -1) {
-            throw new TunTapError('Could not parse interface statistics');
+        if (this._isClosed) {
+            throw new TunTapError('Device has been closed');
         }
-
-        const rxLine = lines[rxIndex + 1]?.trim();
-        const txLine = lines[txIndex + 1]?.trim();
-        if (!rxLine || !txLine) {
-            throw new TunTapError('Could not parse interface statistics: missing data lines');
-        }
-
-        const rxStats = rxLine.split(/\s+/);
-        const txStats = txLine.split(/\s+/);
-        if (rxStats.length < 3 || txStats.length < 3) {
-            throw new TunTapError('Could not parse interface statistics: unexpected format');
-        }
-
-        return {
-            rxBytes: parseInt(rxStats[0], 10) || 0,
-            rxPackets: parseInt(rxStats[1], 10) || 0,
-            rxErrors: parseInt(rxStats[2], 10) || 0,
-            txBytes: parseInt(txStats[0], 10) || 0,
-            txPackets: parseInt(txStats[1], 10) || 0,
-            txErrors: parseInt(txStats[2], 10) || 0,
-        };
     }
 }

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,0 +1,32 @@
+/** Base error for TUN/TAP and tunnel configuration failures. */
+export class TunTapError extends Error {
+    public override name = 'TunTapError';
+
+    /**
+     * @param message — human-readable description
+     * @param code — optional machine-readable code (e.g. `EPERM`)
+     */
+    constructor(message: string, public code?: string) {
+        super(message);
+    }
+}
+
+/** Raised when the process lacks privileges required for a networking operation (e.g. not running as root). */
+export class TunTapPermissionError extends TunTapError {
+    public override name = 'TunTapPermissionError';
+
+    /** @param message — description including hint to run with appropriate privileges */
+    constructor(message: string) {
+        super(message, 'EPERM');
+    }
+}
+
+/** Raised when the TUN device cannot be opened or is unavailable. */
+export class TunTapDeviceError extends TunTapError {
+    public override name = 'TunTapDeviceError';
+
+    /** @param message — description from the native layer or OS */
+    constructor(message: string) {
+        super(message, 'ENODEV');
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,7 @@
-
+export {
+    TunTapDeviceError,
+    TunTapError,
+    TunTapPermissionError,
+} from './errors.js';
 export { TunTap, type PacketCallback } from './TunTap.js';
 export * from './tunnel.js';

--- a/src/platform/create-platform.ts
+++ b/src/platform/create-platform.ts
@@ -1,0 +1,16 @@
+import { DarwinTunTapPlatform } from './darwin.js';
+import { LinuxTunTapPlatform } from './linux.js';
+import type { TunTapPlatform } from './types.js';
+import { UnsupportedTunTapPlatform } from './unsupported.js';
+
+/** @internal Built-in {@link TunTapPlatform} for a Node `process.platform` value. */
+export function createTunTapPlatform(platform: NodeJS.Platform): TunTapPlatform {
+    switch (platform) {
+        case 'darwin':
+            return new DarwinTunTapPlatform();
+        case 'linux':
+            return new LinuxTunTapPlatform();
+        default:
+            return new UnsupportedTunTapPlatform(platform);
+    }
+}

--- a/src/platform/darwin.ts
+++ b/src/platform/darwin.ts
@@ -1,0 +1,59 @@
+import { TunTapError } from '../errors.js';
+import { execFileAsync } from './exec.js';
+import { assertEffectiveRoot } from './require-root.js';
+import type { TunTapInterfaceStats, TunTapPlatform } from './types.js';
+
+/** macOS implementation using `ifconfig`, `route`, and `netstat`. */
+export class DarwinTunTapPlatform implements TunTapPlatform {
+    /** @inheritdoc */
+    async configure(interfaceName: string, address: string, mtu: number): Promise<void> {
+        assertEffectiveRoot();
+        await execFileAsync('ifconfig', [
+            interfaceName,
+            'inet6',
+            address,
+            'prefixlen',
+            '64',
+            'up',
+        ]);
+        await execFileAsync('ifconfig', [interfaceName, 'mtu', String(mtu)]);
+    }
+
+    /** @inheritdoc */
+    async addRoute(interfaceName: string, destination: string): Promise<void> {
+        assertEffectiveRoot();
+        await execFileAsync('route', [
+            '-n',
+            'add',
+            '-inet6',
+            destination,
+            '-interface',
+            interfaceName,
+        ]);
+    }
+
+    /** @inheritdoc */
+    async removeRoute(_interfaceName: string, destination: string): Promise<void> {
+        assertEffectiveRoot();
+        await execFileAsync('route', ['-n', 'delete', '-inet6', destination]);
+    }
+
+    /** @inheritdoc */
+    async getStats(interfaceName: string): Promise<TunTapInterfaceStats> {
+        const { stdout } = await execFileAsync('netstat', ['-I', interfaceName, '-b']);
+        const lines = stdout.trim().split('\n');
+        if (lines.length < 2) {
+            throw new TunTapError('Unexpected netstat output');
+        }
+
+        const stats = lines[1].split(/\s+/);
+        return {
+            rxPackets: parseInt(stats[4], 10) || 0,
+            rxErrors: parseInt(stats[5], 10) || 0,
+            rxBytes: parseInt(stats[6], 10) || 0,
+            txPackets: parseInt(stats[7], 10) || 0,
+            txErrors: parseInt(stats[8], 10) || 0,
+            txBytes: parseInt(stats[9], 10) || 0,
+        };
+    }
+}

--- a/src/platform/exec.ts
+++ b/src/platform/exec.ts
@@ -1,0 +1,4 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+export const execFileAsync = promisify(execFile);

--- a/src/platform/linux.ts
+++ b/src/platform/linux.ts
@@ -1,0 +1,90 @@
+import type { ExecException } from 'node:child_process';
+
+import { log } from '../logger.js';
+import { TunTapError } from '../errors.js';
+import { execFileAsync } from './exec.js';
+import { assertEffectiveRoot } from './require-root.js';
+import type { TunTapInterfaceStats, TunTapPlatform } from './types.js';
+
+/** Linux implementation using `ip` from iproute2. */
+export class LinuxTunTapPlatform implements TunTapPlatform {
+    /** @inheritdoc */
+    async configure(interfaceName: string, address: string, mtu: number): Promise<void> {
+        assertEffectiveRoot();
+        try {
+            await execFileAsync('which', ['ip']);
+        } catch {
+            throw new TunTapError(
+                'The "ip" command is not available. Please install iproute2 (e.g., sudo apt install iproute2)',
+            );
+        }
+
+        try {
+            await execFileAsync('ip', ['-6', 'addr', 'add', `${address}/64`, 'dev', interfaceName]);
+        } catch (err: unknown) {
+            // `util.promisify(execFile)` rejects with `ExecException` (extends `Error`; adds `stderr`, `code`, …).
+            const { message } = err as ExecException;
+            if (!message.includes('File exists')) {
+                throw err;
+            }
+            log.warn(`Address ${address} may already be configured on ${interfaceName}`);
+        }
+
+        await execFileAsync('ip', ['link', 'set', 'dev', interfaceName, 'up', 'mtu', String(mtu)]);
+    }
+
+    /** @inheritdoc */
+    async addRoute(interfaceName: string, destination: string): Promise<void> {
+        assertEffectiveRoot();
+        try {
+            await execFileAsync('ip', ['-6', 'route', 'add', destination, 'dev', interfaceName]);
+        } catch (err: unknown) {
+            const { message } = err as ExecException;
+            if (message.includes('File exists')) {
+                log.info(`Route to ${destination} already exists`);
+                return;
+            }
+            throw err;
+        }
+    }
+
+    /** @inheritdoc */
+    async removeRoute(interfaceName: string, destination: string): Promise<void> {
+        assertEffectiveRoot();
+        await execFileAsync('ip', ['-6', 'route', 'del', destination, 'dev', interfaceName]);
+    }
+
+    /** @inheritdoc */
+    async getStats(interfaceName: string): Promise<TunTapInterfaceStats> {
+        const { stdout } = await execFileAsync('ip', ['-s', 'link', 'show', interfaceName]);
+        const lines = stdout.trim().split('\n');
+
+        const rxIndex = lines.findIndex((line) => line.includes('RX:'));
+        const txIndex = lines.findIndex((line) => line.includes('TX:'));
+
+        if (rxIndex === -1 || txIndex === -1) {
+            throw new TunTapError('Could not parse interface statistics');
+        }
+
+        const rxLine = lines[rxIndex + 1]?.trim();
+        const txLine = lines[txIndex + 1]?.trim();
+        if (!rxLine || !txLine) {
+            throw new TunTapError('Could not parse interface statistics: missing data lines');
+        }
+
+        const rxStats = rxLine.split(/\s+/);
+        const txStats = txLine.split(/\s+/);
+        if (rxStats.length < 3 || txStats.length < 3) {
+            throw new TunTapError('Could not parse interface statistics: unexpected format');
+        }
+
+        return {
+            rxBytes: parseInt(rxStats[0], 10) || 0,
+            rxPackets: parseInt(rxStats[1], 10) || 0,
+            rxErrors: parseInt(rxStats[2], 10) || 0,
+            txBytes: parseInt(txStats[0], 10) || 0,
+            txPackets: parseInt(txStats[1], 10) || 0,
+            txErrors: parseInt(txStats[2], 10) || 0,
+        };
+    }
+}

--- a/src/platform/require-root.ts
+++ b/src/platform/require-root.ts
@@ -1,0 +1,14 @@
+import { TunTapPermissionError } from '../errors.js';
+
+/**
+ * Ensures the process has effective superuser privileges (EUID 0).
+ * Privileged `ip` / `ifconfig` / `route` calls are executed directly — no `sudo` subprocess.
+ */
+export function assertEffectiveRoot(): void {
+    const geteuid = process.geteuid;
+    if (typeof geteuid !== 'function' || geteuid.call(process) !== 0) {
+        throw new TunTapPermissionError(
+            'TUN interface configuration and routing require root privileges (effective UID 0)',
+        );
+    }
+}

--- a/src/platform/types.ts
+++ b/src/platform/types.ts
@@ -1,0 +1,52 @@
+/**
+ * Per-interface traffic counters returned by {@link TunTapPlatform.getStats}.
+ */
+export interface TunTapInterfaceStats {
+    rxBytes: number;
+    txBytes: number;
+    rxPackets: number;
+    txPackets: number;
+    rxErrors: number;
+    txErrors: number;
+}
+
+/**
+ * OS-specific commands for configuring the TUN interface (address, MTU, routes, stats).
+ * Built-in Darwin/Linux implementations require **effective UID 0** (run the process as root) for
+ * {@link TunTapPlatform.configure}, {@link TunTapPlatform.addRoute}, and {@link TunTapPlatform.removeRoute}.
+ * Add a new implementation (e.g. Windows) by extending this interface and wiring it in `create-platform.ts`.
+ */
+export interface TunTapPlatform {
+    /**
+     * Assign an IPv6 address (typically /64) and MTU on the interface, and bring it up.
+     *
+     * @param interfaceName — kernel interface name (e.g. `utun7`)
+     * @param address — IPv6 address
+     * @param mtu — link MTU in bytes
+     */
+    configure(interfaceName: string, address: string, mtu: number): Promise<void>;
+
+    /**
+     * Add an IPv6 route via this interface.
+     *
+     * @param interfaceName — kernel interface name
+     * @param destination — IPv6 host or CIDR (e.g. `fd00::1/128`)
+     */
+    addRoute(interfaceName: string, destination: string): Promise<void>;
+
+    /**
+     * Remove an IPv6 route for the given destination.
+     *
+     * @param interfaceName — kernel interface name (ignored on some platforms)
+     * @param destination — same form as passed to {@link TunTapPlatform.addRoute}
+     */
+    removeRoute(interfaceName: string, destination: string): Promise<void>;
+
+    /**
+     * Read RX/TX byte and packet counters for the interface from the OS.
+     *
+     * @param interfaceName — kernel interface name
+     * @returns interface statistics
+     */
+    getStats(interfaceName: string): Promise<TunTapInterfaceStats>;
+}

--- a/src/platform/unsupported.ts
+++ b/src/platform/unsupported.ts
@@ -1,0 +1,36 @@
+import { TunTapError } from '../errors.js';
+import type { TunTapInterfaceStats, TunTapPlatform } from './types.js';
+
+/**
+ * Stub backend for unsupported `process.platform` values; every method throws {@link TunTapError}.
+ */
+export class UnsupportedTunTapPlatform implements TunTapPlatform {
+    /**
+     * @param platformId — value from `process.platform` (or test override)
+     */
+    constructor(private readonly platformId: string) {}
+
+    /** @inheritdoc */
+    async configure(): Promise<void> {
+        this.unsupported();
+    }
+
+    /** @inheritdoc */
+    async addRoute(): Promise<void> {
+        this.unsupported();
+    }
+
+    /** @inheritdoc */
+    async removeRoute(): Promise<void> {
+        this.unsupported();
+    }
+
+    /** @inheritdoc */
+    async getStats(): Promise<TunTapInterfaceStats> {
+        this.unsupported();
+    }
+
+    private unsupported(): never {
+        throw new TunTapError(`Unsupported platform: ${this.platformId}`);
+    }
+}

--- a/src/tunnel.ts
+++ b/src/tunnel.ts
@@ -24,7 +24,25 @@ export interface PacketData {
     payload: Buffer;
 }
 
+/**
+ * Event names and listener argument tuples for {@link TunnelManager}
+ * (matches Node’s `EventEmitter` event map shape).
+ *
+ * @example
+ * tunnelManager.on('data', (packet) => {
+ *   // `packet` is PacketData
+ * });
+ */
+export interface TunnelManagerEvents {
+    data: [packet: PacketData];
+}
+
 export interface PacketConsumer {
+    /**
+     * Invoked for each parsed TCP/UDP payload extracted from the tunnel stream.
+     *
+     * @param packet — decoded addresses, ports, and payload
+     */
     onPacket(packet: PacketData): void;
 }
 
@@ -32,13 +50,21 @@ export interface TunnelConnection {
     Address: string;
     RsdPort?: number;
     tunnelManager: TunnelManager;
+    /** Tear down the tunnel, close the TUN device, and end the socket when appropriate. */
     closer: () => Promise<void>;
+    /** @param consumer — receives packets for the lifetime of the registration */
     addPacketConsumer(consumer: PacketConsumer): void;
+    /** @param consumer — must be the same reference passed to {@link TunnelConnection.addPacketConsumer} */
     removePacketConsumer(consumer: PacketConsumer): void;
+    /** @returns async iterator of packets until the tunnel is stopped */
     getPacketStream(): AsyncIterable<PacketData>;
 }
 
-export class TunnelManager extends EventEmitter {
+/**
+ * Bridges a CoreDevice tunnel `Socket` and a {@link TunTap} interface: IPv6 framing, TUN I/O, and packet fan-out.
+ * Emits {@link TunnelManagerEvents} (currently `data` with {@link PacketData}) for TCP/UDP packets, same as registered consumers.
+ */
+export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
     private tun: TunTap | null;
     private cancelled: boolean;
     private readInterval: NodeJS.Timeout | null;
@@ -48,6 +74,7 @@ export class TunnelManager extends EventEmitter {
     private deviceConn: Socket | null;
     private cleanupPromise: Promise<void> | null;
 
+    /** Creates a manager with no TUN device until {@link TunnelManager.setupInterface} succeeds. */
     constructor() {
         super();
         this.tun = null;
@@ -60,14 +87,29 @@ export class TunnelManager extends EventEmitter {
         this.cleanupPromise = null;
     }
 
+    /**
+     * Register a listener for parsed tunnel packets (in addition to the `data` event).
+     *
+     * @param consumer — object with {@link PacketConsumer.onPacket}
+     */
     addPacketConsumer(consumer: PacketConsumer): void {
         this.packetConsumers.add(consumer);
     }
 
+    /**
+     * Unregister a consumer previously added with {@link TunnelManager.addPacketConsumer}.
+     *
+     * @param consumer — same reference as passed to `addPacketConsumer`
+     */
     removePacketConsumer(consumer: PacketConsumer): void {
         this.packetConsumers.delete(consumer);
     }
 
+    /**
+     * Async iterator over tunnel packets until {@link TunnelManager.stop} sets `cancelled`.
+     *
+     * @yields {@link PacketData} for each TCP/UDP packet
+     */
     async *getPacketStream(): AsyncIterable<PacketData> {
         const queue: PacketData[] = [];
         let resolver: ((value: IteratorResult<PacketData>) => void) | null = null;
@@ -105,6 +147,12 @@ export class TunnelManager extends EventEmitter {
         }
     }
 
+    /**
+     * Open a {@link TunTap}, assign the client IPv6 address/MTU, and add a /128 route to the server.
+     *
+     * @param tunnelInfo — handshake result (client address, MTU, server address)
+     * @returns interface name, MTU, and the live {@link TunTap} instance
+     */
     async setupInterface(tunnelInfo: TunnelInfo): Promise<{ name: string; mtu: number; interface: TunTap }> {
         log.debug(`Setting up tunnel with parameters:`, tunnelInfo);
 
@@ -145,6 +193,11 @@ export class TunnelManager extends EventEmitter {
         }
     }
 
+    /**
+     * Begin bidirectional forwarding: device socket ↔ TUN (requires {@link TunnelManager.setupInterface} first).
+     *
+     * @param deviceConn — connected tunnel socket after the CDTunnel handshake
+     */
     startForwarding(deviceConn: Socket): void {
         if (!this.tun) {
             log.error('TUN device is not set up');
@@ -187,6 +240,21 @@ export class TunnelManager extends EventEmitter {
         deviceConn.on('error', (err: Error) => {
             log.error('Device connection error: ', err);
         });
+    }
+
+    /**
+     * Idempotent shutdown: stop polling, destroy the socket, clear consumers, close the TUN device.
+     *
+     * @returns the same promise if already stopping/stopped
+     */
+    async stop(): Promise<void> {
+        // Prevent multiple concurrent stops
+        if (this.cleanupPromise) {
+            return this.cleanupPromise;
+        }
+
+        this.cleanupPromise = this._performStop();
+        return this.cleanupPromise;
     }
 
     private processBuffer(): void {
@@ -340,16 +408,6 @@ export class TunnelManager extends EventEmitter {
         }, 5); // Poll every 5ms
     }
 
-    async stop(): Promise<void> {
-        // Prevent multiple concurrent stops
-        if (this.cleanupPromise) {
-            return this.cleanupPromise;
-        }
-
-        this.cleanupPromise = this._performStop();
-        return this.cleanupPromise;
-    }
-
     private async _performStop(): Promise<void> {
         const tunName = this.tun ? this.tun.name : 'unknown';
         log.debug(`Stopping tunnel manager for ${tunName}`);
@@ -403,6 +461,12 @@ function formatIPv6Address(buffer: Buffer): string {
     return parts.join(':');
 }
 
+/**
+ * Perform the CDTunnel JSON handshake (8-byte magic + length-prefixed JSON) over `socket`.
+ *
+ * @param socket — connected stream to the tunnel service
+ * @returns parsed tunnel parameters from the device response
+ */
 export async function exchangeCoreTunnelParameters(socket: Socket): Promise<TunnelInfo> {
     return new Promise((resolve, reject) => {
         const request = {
@@ -493,6 +557,12 @@ export async function exchangeCoreTunnelParameters(socket: Socket): Promise<Tunn
     });
 }
 
+/**
+ * End-to-end setup: handshake, TUN configuration, route, and forwarding on `secureServiceSocket`.
+ *
+ * @param secureServiceSocket — tunnel socket (e.g. from lockdown secure service)
+ * @returns connection handle with {@link TunnelConnection.closer} and packet APIs
+ */
 export async function connectToTunnelLockdown(secureServiceSocket: Socket): Promise<TunnelConnection> {
     const tunnelManager = new TunnelManager();
 


### PR DESCRIPTION
### Description
Refactors TUN configuration/routing so Darwin/Linux live behind a shared **`TunTapPlatform`** implementation, with a small internal factory (`create-platform.ts`) and an unsupported stub for other platforms.

**Behavior**
- **No `sudo` in `execFile` argv** — built-in platforms call `ip` / `ifconfig` / `route` directly and **`assertEffectiveRoot()`** (EUID 0) before privileged work.
- **`TunTap`** now takes **`new TunTap(name?, platform?: NodeJS.Platform)`** (defaults to `process.platform`); custom platform injection removed.

**API / structure**
- **`errors.ts`** — `TunTapError` hierarchy (avoids circular imports with `platform/*`).
- **Package entry** — exports **`TunTap`**, errors, **`tunnel`**, **`PacketCallback`** only (no platform factory/classes/types on the barrel).
- **`TunnelManager`** — typed **`TunnelManagerEvents`** for the `data` emission.

**Docs / DX**
- JSDoc on public surfaces; **`CLAUDE.md`** updated to match layout, scripts, and constraints.
