### PR TITLE
feat: Supply the package with prebuilt addon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,6 @@ jobs:
     - name: Install npm dependencies
       run: sfw npm install
 
-    - name: Build native addon
-      run: |
-        # Set environment variable to treat warnings as non-fatal
-        export CXXFLAGS="-Wno-error"
-        npm run build:addon
-
     - name: Build TypeScript
       run: npm run build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ jobs:
   node_matrix:
     uses: appium/appium-workflows/.github/workflows/node-lts-matrix.yml@main
 
+  prebuild:
+    uses: ./.github/workflows/prebuild.yml
+    with:
+      upload-artifacts: false
+
   build-and-test:
     needs:
     - node_matrix

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -13,7 +13,6 @@ on:
 
 permissions:
   contents: read
-  actions: write
 
 jobs:
   prebuild:

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -1,0 +1,60 @@
+# Reusable workflow: N-API prebuild matrix (darwin x64/arm64, linux x64/arm64).
+# Call from CI (PR/push) to verify native builds; call from release with artifacts for npm pack.
+
+name: Prebuild native addon
+
+on:
+  workflow_call:
+    inputs:
+      upload-artifacts:
+        description: Upload each platform .node as a workflow artifact (off for PR smoke builds)
+        type: boolean
+        default: true
+
+permissions:
+  contents: read
+  actions: write
+
+jobs:
+  prebuild:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - runs-on: macos-latest
+            arch: arm64
+            artifact: darwin-arm64
+          - runs-on: macos-latest
+            arch: x64
+            artifact: darwin-x64
+          - runs-on: ubuntu-latest
+            arch: x64
+            artifact: linux-x64
+          - runs-on: ubuntu-24.04-arm
+            arch: arm64
+            artifact: linux-arm64
+    runs-on: ${{ matrix.runs-on }}
+    steps:
+    - uses: actions/checkout@v6
+    - name: Use Node.js LTS
+      uses: actions/setup-node@v6
+      with:
+        node-version: lts/*
+        check-latest: true
+    - name: Install Linux dependencies
+      if: runner.os == 'Linux'
+      run: |
+        sudo apt-get update
+        if ! sudo apt-get install -y linux-headers-$(uname -r); then
+          sudo apt-get install -y linux-headers-generic
+        fi
+    - run: npm install --no-package-lock
+      name: Install dependencies
+    - name: Create N-API prebuild
+      run: npm run build:prebuilds -- --arch ${{ matrix.arch }}
+    - name: Upload prebuild
+      if: inputs.upload-artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: prebuild-${{ matrix.artifact }}
+        path: prebuilds/

--- a/.github/workflows/publish.js.yml
+++ b/.github/workflows/publish.js.yml
@@ -12,7 +12,11 @@ permissions:
   id-token: write # to enable use of OIDC for trusted publishing and npm provenance
 
 jobs:
+  prebuild:
+    uses: ./.github/workflows/prebuild.yml
+
   build:
+    needs: prebuild
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v6
@@ -21,6 +25,18 @@ jobs:
       with:
         node-version: lts/*
         check-latest: true
+    - name: Download prebuilds
+      uses: actions/download-artifact@v4
+      with:
+        pattern: prebuild-*
+        path: prebuild-staging
+    - name: Merge prebuilds
+      run: |
+        mkdir -p prebuilds
+        for dir in prebuild-staging/prebuild-*/; do
+          cp -R "${dir}"* prebuilds/
+        done
+        find prebuilds -type f -name '*.node' | sort
     - run: npm install --no-package-lock
       name: Install dependencies
     - run: npm run test

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,9 @@ bower_components
 # Compiled binary addons (https://nodejs.org/api/addons.html)
 build/Release
 
+# Prebuilds are produced in CI before publish (or via npm run prebuild); do not commit.
+prebuilds/
+
 # Dependency directories
 node_modules/
 jspm_packages/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,11 +8,17 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 # Install dependencies
 npm install
 
-# Build native addon + TypeScript (required before running tests)
+# TypeScript compile (runs on prepare after install; required before tests if lib/ is stale)
 npm run prepare
 
-# Build only the native C++ addon
+# Native addon: install runs node-gyp-build (uses prebuilds/ when present, else compiles)
+npm install
+
+# Build only the native C++ addon (from source)
 npm run build:addon
+
+# Produce N-API prebuilds under prebuilds/ (release CI uses this per OS/arch matrix)
+npm run build:prebuilds
 
 # Build only TypeScript
 npm run build
@@ -70,7 +76,7 @@ A C++17 Node-API (NAPI) addon built via `node-gyp`. It exposes a single `TunDevi
 ### TypeScript layer (`src/`)
 
 - **`errors.ts`** — shared error classes used by `TunTap` and `platform/*`.
-- **`TunTap.ts`** — loads the native addon via `createRequire`, validates IPv6/MTU/buffers, and calls a **`TunTapPlatform`** instance chosen by **`new TunTap(name?, platform?)`** where `platform` is a **`NodeJS.Platform`** string (default `process.platform`). No custom platform object is accepted at runtime; new OS support is wired in **`platform/create-platform.ts`**.
+- **`TunTap.ts`** — loads the native addon via **`node-gyp-build`** (prebuilds or `build/Release`), validates IPv6/MTU/buffers, and calls a **`TunTapPlatform`** instance chosen by **`new TunTap(name?, platform?)`** where `platform` is a **`NodeJS.Platform`** string (default `process.platform`). No custom platform object is accepted at runtime; new OS support is wired in **`platform/create-platform.ts`**.
 - **`platform/*`** — OS-specific **`execFile`** usage for address, MTU, routes, and stats. Built-in Darwin/Linux paths require **effective UID 0** (**`assertEffectiveRoot`**); commands are run **without** embedding `sudo` in argv. **`getStats`** uses read-only tooling where possible without an extra root check.
 - **`tunnel.ts`** — CDTunnel handshake (`exchangeCoreTunnelParameters`), **`TunnelManager`** (typed **`TunnelManagerEvents`** / `data` → **`PacketData`**), and **`connectToTunnelLockdown`**.
 - **`logger.ts`** — thin wrapper around `@appium/support` logger.
@@ -78,7 +84,8 @@ A C++17 Node-API (NAPI) addon built via `node-gyp`. It exposes a single `TunDevi
 
 ### Build output
 
-- `build/Release/tuntap.node` — compiled native addon (loaded at runtime via `createRequire`)
+- `prebuilds/<platform>-<arch>/*.node` — N-API binaries shipped in the npm package (built in release CI)
+- `build/Release/tuntap.node` — local compile fallback (from `npm run build:addon` or `node-gyp-build` at install)
 - `lib/` — compiled TypeScript output; `lib/index.js` is the package entry point
 
 ### Tests

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "clean": "rm -rf build node_modules lib",
     "build": "npx tsc",
     "build:addon": "node-gyp rebuild",
+    "build:prebuilds": "prebuildify --napi --strip",
     "lint": "eslint .",
     "lint:fix": "npm run lint -- --fix",
     "format": "prettier -w ./src ./test",
     "format:check": "prettier --check ./src ./test",
-    "prepare": "npm run build:addon && npm run build",
+    "install": "node-gyp-build",
+    "prepare": "npm run build",
     "test": "sudo npm run test:integration && npm run test:unit",
     "test:unit": "sudo npx mocha 'test/tuntap-unit.spec.mjs' --exit --timeout 2m",
     "test:integration": "sudo npx mocha 'test/tuntap-integration.spec.mjs' --exit --timeout 2m"
@@ -21,7 +23,7 @@
   "files": [
     "src/tuntap.cc",
     "lib",
-    "build",
+    "prebuilds",
     "binding.gyp",
     "package.json",
     "README.md",
@@ -45,6 +47,7 @@
   "dependencies": {
     "@appium/support": "^7.0.0-rc.1",
     "node-addon-api": "^8.5.0",
+    "node-gyp-build": "^4.8.4",
     "typescript": "^6.0.2"
   },
   "devDependencies": {
@@ -54,7 +57,8 @@
     "@types/node": "^25.0.1",
     "conventional-changelog-conventionalcommits": "^9.0.0",
     "semantic-release": "^25.0.2",
-    "prettier": "^3.0.0"
+    "prettier": "^3.0.0",
+    "prebuildify": "^6.0.1"
   },
   "prettier": {
     "bracketSpacing": false,

--- a/src/TunTap.ts
+++ b/src/TunTap.ts
@@ -1,5 +1,7 @@
 import {createRequire} from 'node:module';
 import {isIPv6} from 'node:net';
+import path from 'node:path';
+import {fileURLToPath} from 'node:url';
 
 import {TunTapDeviceError, TunTapError, TunTapPermissionError} from './errors.js';
 import {log} from './logger.js';
@@ -7,6 +9,8 @@ import {createTunTapPlatform} from './platform/create-platform.js';
 import type {TunTapInterfaceStats, TunTapPlatform} from './platform/types.js';
 
 const require = createRequire(import.meta.url);
+/** Package root (contains binding.gyp, prebuilds/, or build/ after compile). */
+const pkgRoot = path.join(fileURLToPath(new URL('.', import.meta.url)), '..');
 const DEFAULT_READ_BUFFER_SIZE = 4096;
 const MAX_BUFFER_SIZE = 0xffff; // 65535
 const DEFAULT_MTU = 1500;
@@ -33,7 +37,7 @@ interface NativeTuntapModule {
   TunDevice: new (name?: string) => NativeTunDevice;
 }
 
-const nativeTuntap = require('../build/Release/tuntap.node') as NativeTuntapModule;
+const nativeTuntap = require('node-gyp-build')(pkgRoot) as NativeTuntapModule;
 
 /**
  * Validates an IPv6 route destination (address with optional CIDR prefix).


### PR DESCRIPTION
This should reduce requirements to customer machines, where previously dev SDK must have been present. With prebuilt addon for supported platforms this is not necessary anymore, and should improve the overall success install rate.