### PR TITLE
chore: Tune further tunnel perf

### DIFF
--- a/src/native/tun_backend_darwin.cc
+++ b/src/native/tun_backend_darwin.cc
@@ -91,8 +91,11 @@ public:
       return ReadPacketStatus::Error;
     }
 
-    out.resize(max_payload_size + kUtunHeaderSize);
-    ssize_t bytes_read = read(fd_.get(), out.data(), out.size());
+    const size_t read_cap = max_payload_size + kUtunHeaderSize;
+    if (read_frame_.size() < read_cap) {
+      read_frame_.resize(read_cap);
+    }
+    ssize_t bytes_read = read(fd_.get(), read_frame_.data(), read_cap);
     if (bytes_read < 0) {
       if (errno == EAGAIN || errno == EWOULDBLOCK) {
         out.clear();
@@ -111,9 +114,8 @@ public:
     }
 
     const auto payload_len = static_cast<size_t>(bytes_read - kUtunHeaderSize);
-    // Collapse the utun 4-byte address-family prefix in-place.
-    memmove(out.data(), out.data() + kUtunHeaderSize, payload_len);
     out.resize(payload_len);
+    memcpy(out.data(), read_frame_.data() + kUtunHeaderSize, payload_len);
     return ReadPacketStatus::Data;
   }
 
@@ -168,6 +170,7 @@ private:
     return false;
   }
 
+  std::vector<uint8_t> read_frame_;
   std::vector<uint8_t> write_frame_;
 };
 

--- a/src/tunnel/buffer-utils.ts
+++ b/src/tunnel/buffer-utils.ts
@@ -1,0 +1,15 @@
+/**
+ * Append socket/TUN chunks without repeated Buffer.concat growth copies.
+ */
+export function appendBuffer(existing: Buffer, chunk: Buffer): Buffer {
+  if (chunk.length === 0) {
+    return existing;
+  }
+  if (existing.length === 0) {
+    return Buffer.from(chunk);
+  }
+  const combined = Buffer.allocUnsafe(existing.length + chunk.length);
+  existing.copy(combined, 0);
+  chunk.copy(combined, existing.length);
+  return combined;
+}

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -15,6 +15,7 @@ import {
   IPPROTO_TCP,
   IPPROTO_UDP,
 } from './constants.js';
+import {appendBuffer} from './buffer-utils.js';
 import type {
   CdTunnelParseResult,
   Ipv6Frame,
@@ -167,6 +168,9 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
     this.deviceConn = deviceConn;
     log.debug(`Starting bidirectional data forwarding for ${this.tun.name}`);
 
+    deviceConn.setNoDelay(true);
+    deviceConn.setKeepAlive(true, 1000);
+
     // Handle data from the device connection
     deviceConn.on('data', (data: Buffer) => {
       if (this.cancelled) {
@@ -174,8 +178,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
       }
 
       try {
-        // Add data to buffer
-        this.buffer = Buffer.concat([this.buffer, data]);
+        this.buffer = appendBuffer(this.buffer, data);
 
         // Process IPv6 packets
         this.processBuffer();
@@ -316,11 +319,11 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
         return;
       }
 
-      if (data.length >= IPV6_HEADER_SIZE) {
+      if (this.hasPacketTap() && data.length >= IPV6_HEADER_SIZE) {
         log.debug(
           `TUN → Device: ${data.length} bytes, IPv6 src=${formatIPv6Address(data.subarray(8, 24))}, dst=${formatIPv6Address(data.subarray(24, 40))}`,
         );
-      } else {
+      } else if (this.hasPacketTap()) {
         log.debug(`TUN → Device: ${data.length} bytes (too small for IPv6 header)`);
       }
 
@@ -476,7 +479,7 @@ function tryParseCdTunnelResponse(buffer: Buffer): CdTunnelParseResult {
 
 function readCdTunnelResponse(socket: Socket, timeoutMs: number): Promise<TunnelInfo> {
   return new Promise((resolve, reject) => {
-    let buffer = Buffer.alloc(0);
+    let buffer: Buffer = Buffer.alloc(0);
 
     const cleanup = () => {
       socket.removeListener('data', onData);
@@ -492,7 +495,7 @@ function readCdTunnelResponse(socket: Socket, timeoutMs: number): Promise<Tunnel
 
     const onData = (chunk: Buffer) => {
       log.debug('Received data chunk:', chunk.length, 'bytes');
-      buffer = Buffer.concat([buffer, chunk]);
+      buffer = appendBuffer(buffer, chunk);
 
       if (buffer.length >= CD_TUNNEL_HEADER_SIZE) {
         const payloadLength = buffer.readUInt16BE(CD_TUNNEL_MAGIC_SIZE);

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -209,12 +209,14 @@ Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
     buffer_size = size;
   }
 
+  // Queue depth > 1 lets the poll thread post the next packet while JS is still
+  // handling the previous callback (still serialized on the main thread).
   tsfn_ = Napi::ThreadSafeFunction::New(
       env,
       info[0].As<Napi::Function>(),
       "TunDeviceDataCallback",
       0,
-      1);
+      8);
 
   uv_loop_t* loop = nullptr;
   napi_status napi_st = napi_get_uv_event_loop(env, &loop);

--- a/test/unit/buffer-utils.spec.mjs
+++ b/test/unit/buffer-utils.spec.mjs
@@ -2,20 +2,20 @@ import assert from 'node:assert';
 
 import {appendBuffer} from '../../lib/tunnel/buffer-utils.js';
 
-describe('appendBuffer', () => {
-  it('returns existing when chunk is empty', () => {
+describe('appendBuffer', function() {
+  it('returns existing when chunk is empty', function() {
     const existing = Buffer.from('abc');
     assert.strictEqual(appendBuffer(existing, Buffer.alloc(0)), existing);
   });
 
-  it('copies chunk when existing is empty', () => {
+  it('copies chunk when existing is empty', function() {
     const chunk = Buffer.from([1, 2, 3]);
     const out = appendBuffer(Buffer.alloc(0), chunk);
     assert.ok(out.equals(chunk));
     assert.notStrictEqual(out, chunk);
   });
 
-  it('concatenates without mutating inputs', () => {
+  it('concatenates without mutating inputs', function() {
     const a = Buffer.from('hello');
     const b = Buffer.from('world');
     const out = appendBuffer(a, b);

--- a/test/unit/buffer-utils.spec.mjs
+++ b/test/unit/buffer-utils.spec.mjs
@@ -1,0 +1,26 @@
+import assert from 'node:assert';
+
+import {appendBuffer} from '../../lib/tunnel/buffer-utils.js';
+
+describe('appendBuffer', () => {
+  it('returns existing when chunk is empty', () => {
+    const existing = Buffer.from('abc');
+    assert.strictEqual(appendBuffer(existing, Buffer.alloc(0)), existing);
+  });
+
+  it('copies chunk when existing is empty', () => {
+    const chunk = Buffer.from([1, 2, 3]);
+    const out = appendBuffer(Buffer.alloc(0), chunk);
+    assert.ok(out.equals(chunk));
+    assert.notStrictEqual(out, chunk);
+  });
+
+  it('concatenates without mutating inputs', () => {
+    const a = Buffer.from('hello');
+    const b = Buffer.from('world');
+    const out = appendBuffer(a, b);
+    assert.strictEqual(out.toString(), 'helloworld');
+    assert.strictEqual(a.toString(), 'hello');
+    assert.strictEqual(b.toString(), 'world');
+  });
+});

--- a/test/unit/buffer-utils.spec.mjs
+++ b/test/unit/buffer-utils.spec.mjs
@@ -2,20 +2,20 @@ import assert from 'node:assert';
 
 import {appendBuffer} from '../../lib/tunnel/buffer-utils.js';
 
-describe('appendBuffer', function() {
-  it('returns existing when chunk is empty', function() {
+describe('appendBuffer', function () {
+  it('returns existing when chunk is empty', function () {
     const existing = Buffer.from('abc');
     assert.strictEqual(appendBuffer(existing, Buffer.alloc(0)), existing);
   });
 
-  it('copies chunk when existing is empty', function() {
+  it('copies chunk when existing is empty', function () {
     const chunk = Buffer.from([1, 2, 3]);
     const out = appendBuffer(Buffer.alloc(0), chunk);
     assert.ok(out.equals(chunk));
     assert.notStrictEqual(out, chunk);
   });
 
-  it('concatenates without mutating inputs', function() {
+  it('concatenates without mutating inputs', function () {
     const a = Buffer.from('hello');
     const b = Buffer.from('world');
     const out = appendBuffer(a, b);


### PR DESCRIPTION
## Summary

Follow-up performance pass on the CoreDevice TUN tunnel after [#45](https://github.com/appium/appium-ios-tuntap/pull/45) (v0.4.1). These changes trim per-packet and per-chunk overhead on the hot path used by RemoteXPC (AFC, zip_conduit, RSD services) when no L4 packet tap is registered.

- **`appendBuffer()`** — Replaces repeated `Buffer.concat` on device→TUN reassembly and CD tunnel handshake reads with a single `allocUnsafe` + two copies per chunk (avoids O(n²) growth copies on large streams).
- **Device socket tuning** — `setNoDelay(true)` and `setKeepAlive(true, 1000)` on the CoreDeviceProxy upstream socket to reduce Nagle delay on bulk transfers.
- **TUN→device logging** — IPv6 parse/format debug logs only run when `hasPacketTap()` is true (install/upload workloads do not use the tap).
- **Darwin `ReadPacket`** — Reuse a `read_frame_` scratch buffer instead of resizing the output vector and `memmove` on every read; payload is copied once into the JS-facing buffer.
- **ThreadSafeFunction queue** — Increase TSFN queue depth from `1` → `8` so the poll thread can enqueue the next packet while the main thread is still handling the previous callback (callbacks remain serialized on the JS thread).

### Benchmark context (appium-ios-remotexpc + VodQA ~208 MiB IPA, zip_conduit `streamOnly`)

Measured with linked `appium-ios-tuntap` + active tunnel; variance between runs is ~10–20%.

| Tunnel | Stream time | Throughput (approx.) |
|--------|-------------|----------------------|
| Network (pre-change baseline) | ~17.5 s | ~11.9 MiB/s |
| Network (with this PR) | ~16.8 s | ~12.4 MiB/s |
| USB (with this PR, best run) | ~15.3 s | ~13.6 MiB/s |

Gains are modest on network (~3–4% on stream upload) because the path is largely bandwidth-bound; USB shows more headroom. Full IPA install wall time is still dominated by on-device staging/install after upload.

## Test plan

- [x] `npm run build && npm run build:addon`
- [x] `npx mocha test/unit/buffer-utils.spec.mjs` — `appendBuffer` unit tests (3 cases)
- [ ] `sudo npm run test:unit` — native TUN tests (requires root)
- [ ] Manual: `appium-ios-remotexpc` tunnel + zip_conduit stream install over USB and/or Network; confirm registry `connectionType` and compare `streamOnly` timings in service logs (`zip_conduit stream finished` at `debug`)

## Notes / non-goals

- No API or behavior change for consumers beyond performance and quieter debug logging when packet tap is off.
- Not included (possible follow-ups): TUN poll pause on `deviceConn.write` backpressure, batching multiple packets per TSFN callback, explicit socket recv/send buffer sizing.

## Related

- Builds on [#45](https://github.com/appium/appium-ios-tuntap/pull/45) / v0.4.1 (event-driven poll, MTU 1280, optional L4 tap, zero-copy native buffers).
- Paired with **appium-ios-remotexpc** tunnel registry fix: prefer first usbmux row per UDID so USB wins when both USB and Network are listed.