### PR TITLE
fix: Improve raw transfer performance

### DIFF
--- a/src/TunTap.ts
+++ b/src/TunTap.ts
@@ -30,7 +30,9 @@ interface NativeTunDevice {
   write(data: Buffer): number;
   getName(): string;
   getFd(): number;
-  startPolling(callback: PacketCallback, bufferSize?: number): void;
+  startPolling(callback: PacketCallback, bufferSize?: number, queueDepth?: number): void;
+  pausePolling(): void;
+  resumePolling(): void;
 }
 
 interface NativeTuntapModule {
@@ -221,7 +223,11 @@ export class TunTap {
    * @throws {TypeError} if `callback` is not a function
    * @throws {RangeError} if `bufferSize` is out of range
    */
-  startPolling(callback: PacketCallback, bufferSize: number = MAX_BUFFER_SIZE): void {
+  startPolling(
+    callback: PacketCallback,
+    bufferSize: number = MAX_BUFFER_SIZE,
+    queueDepth: number = 8,
+  ): void {
     this.assertReady();
     if (typeof callback !== 'function') {
       throw new TypeError('Callback must be a function');
@@ -229,7 +235,26 @@ export class TunTap {
     if (bufferSize <= 0 || bufferSize > MAX_BUFFER_SIZE) {
       throw new RangeError(`Buffer size must be between 1 and ${MAX_BUFFER_SIZE} bytes`);
     }
-    this.device.startPolling(callback, bufferSize);
+    if (queueDepth <= 0 || queueDepth > 64) {
+      throw new RangeError('Queue depth must be between 1 and 64');
+    }
+    this.device.startPolling(callback, bufferSize, queueDepth);
+  }
+
+  /**
+   * Pause libuv-driven polling without tearing down the receive callback.
+   */
+  pausePolling(): void {
+    this.assertReady();
+    this.device.pausePolling();
+  }
+
+  /**
+   * Resume polling after {@link TunTap.pausePolling}.
+   */
+  resumePolling(): void {
+    this.assertReady();
+    this.device.resumePolling();
   }
 
   /**

--- a/src/native/posix_tun_backend.h
+++ b/src/native/posix_tun_backend.h
@@ -47,6 +47,10 @@ public:
 
   void StopReceiveLoop() override { poll_loop_.Stop(); }
 
+  void PauseReceiveLoop() override { poll_loop_.Pause(); }
+
+  void ResumeReceiveLoop() override { poll_loop_.Resume(); }
+
   int GetNativeFd() const override { return fd_.get(); }
 
 protected:

--- a/src/native/posix_uv_poll_loop.cc
+++ b/src/native/posix_uv_poll_loop.cc
@@ -59,12 +59,29 @@ void PosixUvPollLoop::Stop() {
     return;
   }
 
+  paused_ = false;
   uv_poll_stop(handle_);
   handle_->data = nullptr;
   uv_close(reinterpret_cast<uv_handle_t*>(handle_),
            &PosixUvPollLoop::OnHandleClosed);
   handle_ = nullptr;
   state_.reset();
+}
+
+void PosixUvPollLoop::Pause() {
+  if (!handle_ || paused_) {
+    return;
+  }
+  paused_ = true;
+  uv_poll_stop(handle_);
+}
+
+void PosixUvPollLoop::Resume() {
+  if (!handle_ || !paused_) {
+    return;
+  }
+  paused_ = false;
+  uv_poll_start(handle_, UV_READABLE, &PosixUvPollLoop::OnPoll);
 }
 
 void PosixUvPollLoop::OnPoll(uv_poll_t* handle, int status, int events) {

--- a/src/native/posix_uv_poll_loop.h
+++ b/src/native/posix_uv_poll_loop.h
@@ -33,8 +33,11 @@ public:
              std::string& error);
 
   void Stop();
+  void Pause();
+  void Resume();
 
 private:
+  bool paused_ = false;
   struct State {
     size_t buffer_size = 0;
     ReadFn read_fn;

--- a/src/native/tun_backend.h
+++ b/src/native/tun_backend.h
@@ -72,6 +72,10 @@ public:
                                 std::string& error) = 0;
   virtual void StopReceiveLoop() = 0;
 
+  // Temporarily stop delivering packets without tearing down the receive loop.
+  virtual void PauseReceiveLoop() {}
+  virtual void ResumeReceiveLoop() {}
+
   // Returns the underlying POSIX file descriptor when one exists. Backends
   // without a numeric fd (e.g. Wintun on Windows) return `-1`.
   virtual int GetNativeFd() const { return -1; }

--- a/src/native/tun_backend_windows.cc
+++ b/src/native/tun_backend_windows.cc
@@ -238,15 +238,21 @@ public:
       // Either never started or already cleaned up. Reset the event in case
       // it was created without ever spawning a thread.
       quit_event_.reset();
+      receive_paused_.store(false);
       return;
     }
     worker_running_.store(false);
+    receive_paused_.store(false);
     if (quit_event_.is_valid()) {
       ::SetEvent(quit_event_.get());
     }
     worker_.join();
     quit_event_.reset();
   }
+
+  void PauseReceiveLoop() override { receive_paused_.store(true); }
+
+  void ResumeReceiveLoop() override { receive_paused_.store(false); }
 
   // WinTun exposes no POSIX file descriptor: its readable object is a Win32
   // event `HANDLE`, not a numeric fd. Always -1 — the N-API layer treats -1
@@ -293,11 +299,18 @@ private:
     HANDLE wait_handles[2] = {read_event_, quit_event_.get()};
 
     while (worker_running_.load()) {
+      while (receive_paused_.load() && worker_running_.load()) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      }
+      if (!worker_running_.load()) {
+        return;
+      }
+
       // Drain everything available before going back to wait. WinTun's
       // read-wait event is auto-reset on signal, so we must consume all
       // queued packets before re-arming.
       bool drained = false;
-      while (worker_running_.load()) {
+      while (worker_running_.load() && !receive_paused_.load()) {
         DWORD packet_size = 0;
         BYTE* packet = api.ReceivePacket(session_, &packet_size);
         if (packet) {
@@ -358,6 +371,7 @@ private:
   Handle quit_event_;
   std::thread worker_;
   std::atomic<bool> worker_running_{false};
+  std::atomic<bool> receive_paused_{false};
   std::string interface_name_;
 };
 

--- a/src/tunnel/constants.ts
+++ b/src/tunnel/constants.ts
@@ -1,5 +1,13 @@
 /** CDTunnel lockdown handshake MTU (IPv6 minimum). */
 export const CD_TUNNEL_MTU = 1280;
+/** Upper bound for native TUN poll read size (matches N-API addon). */
+export const MAX_TUN_POLL_BUFFER = 65_535;
+/** Preferred poll read size when L4 packet tap is off. */
+export const LARGE_TUN_POLL_BUFFER = 64 * 1024;
+/** Default ThreadSafeFunction queue depth for TUN polling. */
+export const DEFAULT_TUN_POLL_QUEUE_DEPTH = 8;
+/** Deeper TSFN queue when packet tap is off (bulk transfer). */
+export const FAST_TUN_POLL_QUEUE_DEPTH = 16;
 export const CD_TUNNEL_MAGIC = 'CDTunnel';
 export const CD_TUNNEL_MAGIC_SIZE = 8;
 export const CD_TUNNEL_HEADER_SIZE = CD_TUNNEL_MAGIC_SIZE + 2;

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -10,7 +10,11 @@ import {
   CD_TUNNEL_MAGIC,
   CD_TUNNEL_MAGIC_SIZE,
   CD_TUNNEL_MTU,
+  DEFAULT_TUN_POLL_QUEUE_DEPTH,
+  FAST_TUN_POLL_QUEUE_DEPTH,
   IPV6_HEADER_SIZE,
+  LARGE_TUN_POLL_BUFFER,
+  MAX_TUN_POLL_BUFFER,
   IPV6_VERSION,
   IPPROTO_TCP,
   IPPROTO_UDP,
@@ -38,6 +42,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
   private readonly packetConsumers: Set<PacketConsumer> = new Set();
   private deviceConn: Socket | null = null;
   private cleanupPromise: Promise<void> | null = null;
+  private tunReadPausedForBackpressure = false;
 
   /**
    * Register a listener for parsed tunnel packets (in addition to the `data` event).
@@ -254,17 +259,22 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
     }
 
     if (offset > 0) {
-      this.buffer = this.buffer.subarray(offset);
+      if (offset >= this.buffer.length) {
+        this.buffer = Buffer.alloc(0);
+      } else {
+        this.buffer = this.buffer.subarray(offset);
+      }
     }
   }
 
   private writeDeviceFrameToTun(tun: TunTap, packet: Buffer, nextHeader: number): void {
-    const bytesWritten = tun.write(packet);
+    tun.write(packet);
 
     if (!this.hasPacketTap()) {
-      log.debug(`Device → TUN: ${bytesWritten} bytes`);
       return;
     }
+
+    const bytesWritten = packet.length;
 
     const {src, dst} = ipv6Endpoints(packet);
     log.debug(`Device → TUN: ${bytesWritten} bytes, IPv6 src=${src}, dst=${dst}`);
@@ -314,21 +324,55 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
       return;
     }
 
-    this.tun.startPolling((data: Buffer) => {
-      if (this.cancelled || !data.length || deviceConn.destroyed) {
+    const tapOn = this.hasPacketTap();
+    const pollBuffer = tapOn
+      ? this.mtu
+      : Math.min(MAX_TUN_POLL_BUFFER, Math.max(this.mtu, LARGE_TUN_POLL_BUFFER));
+    const queueDepth = tapOn ? DEFAULT_TUN_POLL_QUEUE_DEPTH : FAST_TUN_POLL_QUEUE_DEPTH;
+
+    this.tun.startPolling(
+      (data: Buffer) => {
+        if (this.cancelled || !data.length || deviceConn.destroyed) {
+          return;
+        }
+
+        if (tapOn && data.length >= IPV6_HEADER_SIZE) {
+          log.debug(
+            `TUN → Device: ${data.length} bytes, IPv6 src=${formatIPv6Address(data.subarray(8, 24))}, dst=${formatIPv6Address(data.subarray(24, 40))}`,
+          );
+        } else if (tapOn) {
+          log.debug(`TUN → Device: ${data.length} bytes (too small for IPv6 header)`);
+        }
+
+        this.writeTunPacketToDevice(deviceConn, data);
+      },
+      pollBuffer,
+      queueDepth,
+    );
+  }
+
+  private writeTunPacketToDevice(deviceConn: Socket, data: Buffer): void {
+    if (deviceConn.destroyed) {
+      return;
+    }
+
+    const canWriteMore = deviceConn.write(data);
+    if (canWriteMore || this.tunReadPausedForBackpressure || !this.tun) {
+      return;
+    }
+
+    this.tunReadPausedForBackpressure = true;
+    this.tun.pausePolling();
+
+    const onDrain = (): void => {
+      if (this.cancelled || deviceConn.destroyed) {
         return;
       }
+      this.tunReadPausedForBackpressure = false;
+      this.tun?.resumePolling();
+    };
 
-      if (this.hasPacketTap() && data.length >= IPV6_HEADER_SIZE) {
-        log.debug(
-          `TUN → Device: ${data.length} bytes, IPv6 src=${formatIPv6Address(data.subarray(8, 24))}, dst=${formatIPv6Address(data.subarray(24, 40))}`,
-        );
-      } else if (this.hasPacketTap()) {
-        log.debug(`TUN → Device: ${data.length} bytes (too small for IPv6 header)`);
-      }
-
-      deviceConn.write(data);
-    }, this.mtu);
+    deviceConn.once('drain', onDrain);
   }
 
   private async _performStop(): Promise<void> {

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -28,6 +28,8 @@ private:
   Napi::Value GetName(const Napi::CallbackInfo& info);
   Napi::Value GetFd(const Napi::CallbackInfo& info);
   Napi::Value StartPolling(const Napi::CallbackInfo& info);
+  Napi::Value PausePolling(const Napi::CallbackInfo& info);
+  Napi::Value ResumePolling(const Napi::CallbackInfo& info);
 
   std::unique_ptr<TunPlatformBackend> backend_;
   std::string requested_name_;
@@ -56,6 +58,8 @@ Napi::Object TunDevice::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod("getName", &TunDevice::GetName),
     InstanceMethod("getFd", &TunDevice::GetFd),
     InstanceMethod("startPolling", &TunDevice::StartPolling),
+    InstanceMethod("pausePolling", &TunDevice::PausePolling),
+    InstanceMethod("resumePolling", &TunDevice::ResumePolling),
   });
 
   constructor = Napi::Persistent(func);
@@ -209,6 +213,15 @@ Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
     buffer_size = size;
   }
 
+  size_t queue_depth = 8;
+  if (info.Length() > 2 && info[2].IsNumber()) {
+    queue_depth = info[2].As<Napi::Number>().Uint32Value();
+    if (queue_depth == 0 || queue_depth > 64) {
+      Napi::RangeError::New(env, "Queue depth must be between 1 and 64").ThrowAsJavaScriptException();
+      return env.Null();
+    }
+  }
+
   // Queue depth > 1 lets the poll thread post the next packet while JS is still
   // handling the previous callback (still serialized on the main thread).
   tsfn_ = Napi::ThreadSafeFunction::New(
@@ -216,7 +229,7 @@ Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
       info[0].As<Napi::Function>(),
       "TunDeviceDataCallback",
       0,
-      8);
+      queue_depth);
 
   uv_loop_t* loop = nullptr;
   napi_status napi_st = napi_get_uv_event_loop(env, &loop);
@@ -262,6 +275,30 @@ Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
   }
 
   polling_ = true;
+  return env.Undefined();
+}
+
+Napi::Value TunDevice::PausePolling(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  std::lock_guard<std::mutex> lock(device_mutex_);
+
+  if (!polling_ || !backend_ || !backend_->IsOpen()) {
+    return env.Undefined();
+  }
+
+  backend_->PauseReceiveLoop();
+  return env.Undefined();
+}
+
+Napi::Value TunDevice::ResumePolling(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  std::lock_guard<std::mutex> lock(device_mutex_);
+
+  if (!polling_ || !backend_ || !backend_->IsOpen()) {
+    return env.Undefined();
+  }
+
+  backend_->ResumeReceiveLoop();
   return env.Undefined();
 }
 

--- a/test/unit/buffer-utils.spec.mjs
+++ b/test/unit/buffer-utils.spec.mjs
@@ -23,4 +23,9 @@ describe('appendBuffer', function () {
     assert.strictEqual(a.toString(), 'hello');
     assert.strictEqual(b.toString(), 'world');
   });
+
+  it('reuses existing buffer when appending an empty chunk', function () {
+    const existing = Buffer.alloc(4096);
+    assert.strictEqual(appendBuffer(existing, Buffer.alloc(0)), existing);
+  });
 });

--- a/test/unit/tunnel/manager-forwarding.spec.mjs
+++ b/test/unit/tunnel/manager-forwarding.spec.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert';
+import {EventEmitter} from 'node:events';
+
+import {
+  DEFAULT_TUN_POLL_QUEUE_DEPTH,
+  FAST_TUN_POLL_QUEUE_DEPTH,
+  LARGE_TUN_POLL_BUFFER,
+  MAX_TUN_POLL_BUFFER,
+} from '../../../lib/tunnel/constants.js';
+import {TunnelManager} from '../../../lib/tunnel/manager.js';
+
+class MockTunTap {
+  constructor() {
+    this.name = 'utun-mock';
+    this.pollBuffer = null;
+    this.queueDepth = null;
+    this.paused = false;
+    this.callback = null;
+  }
+
+  open() {
+    return true;
+  }
+
+  close() {}
+
+  write() {
+    return 0;
+  }
+
+  async configure() {}
+
+  async addRoute() {}
+
+  startPolling(callback, bufferSize, queueDepth) {
+    this.callback = callback;
+    this.pollBuffer = bufferSize;
+    this.queueDepth = queueDepth;
+  }
+
+  pausePolling() {
+    this.paused = true;
+  }
+
+  resumePolling() {
+    this.paused = false;
+  }
+}
+
+class MockSocket extends EventEmitter {
+  constructor() {
+    super();
+    this.destroyed = false;
+    this.writableNeedDrain = false;
+    this._writable = true;
+  }
+
+  setNoDelay() {}
+
+  setKeepAlive() {}
+
+  write(data) {
+    this.emit('written', data);
+    return this._writable;
+  }
+
+  destroy() {
+    this.destroyed = true;
+    this.emit('close');
+  }
+}
+
+describe('TunnelManager forwarding', function () {
+  it('uses a larger poll buffer and deeper queue when packet tap is off', function () {
+    const manager = new TunnelManager();
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+
+    manager.tun = tun;
+    manager.mtu = 1280;
+    manager.startTunReadLoop(socket);
+
+    assert.strictEqual(
+      tun.pollBuffer,
+      Math.min(MAX_TUN_POLL_BUFFER, Math.max(1280, LARGE_TUN_POLL_BUFFER)),
+    );
+    assert.strictEqual(tun.queueDepth, FAST_TUN_POLL_QUEUE_DEPTH);
+  });
+
+  it('uses MTU-sized poll buffer and default queue when packet tap is on', function () {
+    const manager = new TunnelManager();
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+
+    manager.addPacketConsumer({onPacket: () => {}});
+    manager.tun = tun;
+    manager.mtu = 1280;
+    manager.startTunReadLoop(socket);
+
+    assert.strictEqual(tun.pollBuffer, 1280);
+    assert.strictEqual(tun.queueDepth, DEFAULT_TUN_POLL_QUEUE_DEPTH);
+  });
+
+  it('pauses TUN polling when the device socket write buffer fills', function () {
+    const manager = new TunnelManager();
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+    socket._writable = false;
+
+    manager.tun = tun;
+    manager.mtu = 1280;
+    manager.startTunReadLoop(socket);
+
+    const packet = Buffer.from([0x60, 0, 0, 0, 0, 0, 0, 0]);
+    tun.callback(packet);
+
+    assert.strictEqual(tun.paused, true);
+    assert.strictEqual(manager.tunReadPausedForBackpressure, true);
+
+    socket._writable = true;
+    socket.emit('drain');
+
+    assert.strictEqual(tun.paused, false);
+    assert.strictEqual(manager.tunReadPausedForBackpressure, false);
+  });
+});


### PR DESCRIPTION
## Summary

Improves CoreDevice tunnel bridge throughput on the hot path (host ↔ utun ↔ TLS socket) when L4 packet tap is off. Targets bulk transfers like zip_conduit IPA installs.

Previously every TUN→device frame used a 1280-byte poll buffer (MTU), ignored socket write backpressure, and used a shallow TSFN queue — adding per-packet overhead on large uploads.

### Changes

**JS bridge (`TunnelManager`)**
- **Larger poll buffer when tap is off** — `64 KiB` (capped at 65535) instead of MTU-only (1280); keeps MTU buffer when packet tap is active
- **Socket write backpressure** — on `deviceConn.write()` returning false, pauses native TUN polling and resumes on `'drain'`
- **Reassembly buffer compaction** — drops backing store with `Buffer.alloc(0)` when fully consumed
- **Fast-path logging** — removes per-frame `Device → TUN` debug logging when tap is off
- **Deeper TSFN queue when tap is off** — queue depth 16 vs default 8

**Native addon**
- `pausePolling()` / `resumePolling()` — pause `uv_poll` (POSIX) or WinTun worker (Windows) without tearing down the receive loop
- Configurable TSFN queue depth via 3rd `startPolling` argument (default 8, max 64)

**Tests**
- `test/unit/tunnel/manager-forwarding.spec.mjs` — poll buffer sizing, queue depth, backpressure pause/resume
- Extended `buffer-utils.spec.mjs`

### Benchmark (appium-ios-remotexpc `test:zipconduit-install`)

`VodQAReactNative.ipa` (~200 MiB), tunnel + lazy packet tap (no stream clients), WiFi:

| Run | Total install | Stream phase (tunnel-heavy) |
|-----|---------------|----------------------------|
| 1 | 9.49s | 5.85s (~35.6 MiB/s) |
| 2 | 9.58s | 5.94s (~35.0 MiB/s) |
| 3 | 9.73s | 6.10s (~34.1 MiB/s) |
| **Median** | **9.58s** | **5.94s** |

Prior remotexpc zip_conduit baseline was ~20–21s (tap off); legacy usbmux ~14s. This run beats both, though connection type (WiFi vs USB) may affect comparability — a USB rerun is recommended for apples-to-apples.

Pairs with **appium-ios-remotexpc** lazy `PacketStreamServer` attach (tap off unless clients connected).
