### PR TITLE
feat: Switch to a different tunnelling architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "refresh:wintun": "node scripts/fetch-wintun.mjs",
     "prepare": "npm run build",
     "test": "npm run test:integration && npm run test:unit",
-    "test:unit": "node --test --test-force-exit --test-timeout=120000 \"test/unit/**/*.spec.mjs\"",
-    "test:integration": "node --test --test-force-exit --test-timeout=120000 \"test/integration/**/*.spec.mjs\""
+    "test:unit": "node --test --test-force-exit --test-timeout=5000 \"test/unit/**/*.spec.mjs\"",
+    "test:integration": "node --test --test-force-exit --test-timeout=15000 \"test/integration/**/*.spec.mjs\""
   },
   "files": [
     "src/tuntap.cc",

--- a/src/native/posix_uv_poll_loop.cc
+++ b/src/native/posix_uv_poll_loop.cc
@@ -121,8 +121,8 @@ void PosixUvPollLoop::OnPoll(uv_poll_t* handle, int status, int events) {
 
     switch (rs) {
       case ReadPacketStatus::Data:
-        if (state->on_packet) {
-          state->on_packet(std::move(packet));
+        if (state->on_packet && !state->on_packet(std::move(packet))) {
+          return;
         }
         break;
       case ReadPacketStatus::NoData:

--- a/src/native/tun_backend.h
+++ b/src/native/tun_backend.h
@@ -42,7 +42,7 @@ public:
   // background thread (libuv loop thread on POSIX, worker thread on Windows);
   // the caller in `tuntap.cc` is responsible for marshalling onto the JS
   // thread via `Napi::ThreadSafeFunction`.
-  using PacketCallback = std::function<void(std::vector<uint8_t>)>;
+  using PacketCallback = std::function<bool(std::vector<uint8_t>)>;
 
   // Invoked at most once when the receive loop encounters a fatal error and
   // stops. The receive loop must not deliver any further packets afterwards.

--- a/src/native/tun_backend_windows.cc
+++ b/src/native/tun_backend_windows.cc
@@ -319,8 +319,8 @@ private:
                                       : static_cast<size_t>(packet_size);
           std::vector<uint8_t> data(packet, packet + copy_len);
           api.ReleaseReceivePacket(session_, packet);
-          if (on_packet) {
-            on_packet(std::move(data));
+          if (on_packet && !on_packet(std::move(data))) {
+            break;
           }
           continue;
         }

--- a/src/platform/windows.ts
+++ b/src/platform/windows.ts
@@ -2,6 +2,7 @@ import type {ExecException} from 'node:child_process';
 
 import {TunTapError} from '../errors.js';
 import {log} from '../logger.js';
+import {tunDebug} from '../tunnel/debug-log.js';
 import {assertAdminOnWindows} from './require-admin.js';
 import {execFileAsync} from './exec.js';
 import type {TunTapInterfaceStats, TunTapPlatform} from './types.js';
@@ -25,7 +26,7 @@ export class WindowsTunTapPlatform implements TunTapPlatform {
   async configure(interfaceName: string, address: string, mtu: number): Promise<void> {
     await assertAdminOnWindows();
     assertSafeAdapterName(interfaceName);
-    log.debug(`[win] configure: interface=${interfaceName} address=${address} mtu=${mtu}`);
+    tunDebug(`[win] configure: interface=${interfaceName} address=${address} mtu=${mtu}`);
 
     await addIpv6Address(interfaceName, address);
     await setIpv6Mtu(interfaceName, mtu);
@@ -36,7 +37,7 @@ export class WindowsTunTapPlatform implements TunTapPlatform {
     await assertAdminOnWindows();
     assertSafeAdapterName(interfaceName);
 
-    log.debug(`[win] addRoute: interface=${interfaceName} destination=${destination}`);
+    tunDebug(`[win] addRoute: interface=${interfaceName} destination=${destination}`);
 
     await addIpv6Route(interfaceName, destination);
 
@@ -124,7 +125,7 @@ async function addIpv6Address(interfaceName: string, address: string): Promise<v
       `address=${address}/64`,
       'store=active',
     ]);
-    log.debug(`[win] add address ok: ${r.stdout.trim() || '(no output)'}`);
+    tunDebug(`[win] add address ok: ${r.stdout.trim() || '(no output)'}`);
   } catch (err: unknown) {
     const message = (err as ExecException).message ?? '';
     log.warn(`[win] add address err: ${message}`);
@@ -146,7 +147,7 @@ async function setIpv6Mtu(interfaceName: string, mtu: number): Promise<void> {
       `mtu=${mtu}`,
       'store=active',
     ]);
-    log.debug(`[win] set mtu ok: ${r.stdout.trim() || '(no output)'}`);
+    tunDebug(`[win] set mtu ok: ${r.stdout.trim() || '(no output)'}`);
   } catch (err: unknown) {
     log.warn(`[win] set mtu err: ${(err as ExecException).message ?? err}`);
     throw err;
@@ -164,12 +165,12 @@ async function addIpv6Route(interfaceName: string, destination: string): Promise
       interfaceName,
       'store=active',
     ]);
-    log.debug(`[win] add route ok: ${r.stdout.trim() || '(no output)'}`);
+    tunDebug(`[win] add route ok: ${r.stdout.trim() || '(no output)'}`);
   } catch (err: unknown) {
     const message = (err as ExecException).message ?? '';
     log.warn(`[win] add route err: ${message}`);
     if (/already exists|object already/i.test(message)) {
-      log.debug(`Route to ${destination} already exists`);
+      tunDebug(`Route to ${destination} already exists`);
       return;
     }
     throw err;
@@ -196,7 +197,7 @@ async function deleteIpv6Route(interfaceName: string, destination: string): Prom
 }
 
 async function addStaticNeighbor(interfaceName: string, address: string): Promise<void> {
-  log.debug(`[win] addStaticNeighbor: interface=${interfaceName} address=${address}`);
+  tunDebug(`[win] addStaticNeighbor: interface=${interfaceName} address=${address}`);
   try {
     const r = await execFileAsync('netsh', [
       'interface',
@@ -208,7 +209,7 @@ async function addStaticNeighbor(interfaceName: string, address: string): Promis
       '00-00-00-00-00-01',
       'store=active',
     ]);
-    log.debug(`[win] add neighbor ok: ${r.stdout.trim() || '(no output)'}`);
+    tunDebug(`[win] add neighbor ok: ${r.stdout.trim() || '(no output)'}`);
   } catch (err) {
     const msg = (err as ExecException).message ?? String(err);
     log.warn(`[win] add neighbor err: ${msg}`);

--- a/src/tunnel/constants.ts
+++ b/src/tunnel/constants.ts
@@ -8,14 +8,10 @@ export const LARGE_TUN_POLL_BUFFER = 64 * 1024;
 export const DEFAULT_TUN_POLL_QUEUE_DEPTH = 8;
 /** One in-flight TUN read for sequential pump forwarding. */
 export const SEQUENTIAL_TUN_POLL_QUEUE_DEPTH = 1;
-/** Max utun packets buffered on the JS side before TLS write. */
-export const MAX_TUN_INGRESS_QUEUE = 256;
-/** Max ThreadSafeFunction queue depth (native addon limit). */
-export const MAX_TUN_POLL_TSFN_QUEUE_DEPTH = 64;
-/** ThreadSafeFunction queue depth passed to {@link TunTap.startPolling}. */
-export const TUN_POLL_TSFN_QUEUE_DEPTH = MAX_TUN_POLL_TSFN_QUEUE_DEPTH;
-/** Yield device→TUN loop periodically so utun poll callbacks can run. */
-export const DEVICE_PUMP_YIELD_EVERY_FRAMES = 64;
+/** Max utun packets buffered between poll and TLS write (native poll may burst-read). */
+export const MAX_TUN_INGRESS_QUEUE = 64;
+/** ThreadSafeFunction queue depth for utun poll (must match ingress buffer). */
+export const TUN_POLL_TSFN_QUEUE_DEPTH = MAX_TUN_INGRESS_QUEUE;
 
 export const CD_TUNNEL_MAGIC = 'CDTunnel';
 export const CD_TUNNEL_MAGIC_SIZE = 8;

--- a/src/tunnel/constants.ts
+++ b/src/tunnel/constants.ts
@@ -6,17 +6,26 @@ export const MAX_TUN_POLL_BUFFER = 65_535;
 export const LARGE_TUN_POLL_BUFFER = 64 * 1024;
 /** Default ThreadSafeFunction queue depth for TUN polling. */
 export const DEFAULT_TUN_POLL_QUEUE_DEPTH = 8;
-/** Deeper TSFN queue when packet tap is off (bulk transfer). */
-export const FAST_TUN_POLL_QUEUE_DEPTH = 16;
+/** One in-flight TUN read for sequential pump forwarding. */
+export const SEQUENTIAL_TUN_POLL_QUEUE_DEPTH = 1;
+/** Max utun packets buffered on the JS side before TLS write. */
+export const MAX_TUN_INGRESS_QUEUE = 256;
+/** Max ThreadSafeFunction queue depth (native addon limit). */
+export const MAX_TUN_POLL_TSFN_QUEUE_DEPTH = 64;
+/** ThreadSafeFunction queue depth passed to {@link TunTap.startPolling}. */
+export const TUN_POLL_TSFN_QUEUE_DEPTH = MAX_TUN_POLL_TSFN_QUEUE_DEPTH;
+/** Yield device→TUN loop periodically so utun poll callbacks can run. */
+export const DEVICE_PUMP_YIELD_EVERY_FRAMES = 64;
+
 export const CD_TUNNEL_MAGIC = 'CDTunnel';
 export const CD_TUNNEL_MAGIC_SIZE = 8;
 export const CD_TUNNEL_HEADER_SIZE = CD_TUNNEL_MAGIC_SIZE + 2;
 export const CD_TUNNEL_HANDSHAKE_TIMEOUT_MS = 30_000;
 
+/** Pause device ingress when the reassembly buffer exceeds this size. */
+export const MAX_DEVICE_INGRESS_BUFFER = 8 * 1024 * 1024;
+
 export const IPV6_HEADER_SIZE = 40;
 export const IPV6_VERSION = 6;
 export const IPPROTO_TCP = 6;
 export const IPPROTO_UDP = 17;
-
-/** Pause device ingress when the reassembly buffer exceeds this size. */
-export const MAX_DEVICE_INGRESS_BUFFER = 8 * 1024 * 1024;

--- a/src/tunnel/constants.ts
+++ b/src/tunnel/constants.ts
@@ -8,10 +8,14 @@ export const LARGE_TUN_POLL_BUFFER = 64 * 1024;
 export const DEFAULT_TUN_POLL_QUEUE_DEPTH = 8;
 /** One in-flight TUN read for sequential pump forwarding. */
 export const SEQUENTIAL_TUN_POLL_QUEUE_DEPTH = 1;
-/** Max utun packets buffered between poll and TLS write (native poll may burst-read). */
-export const MAX_TUN_INGRESS_QUEUE = 64;
-/** ThreadSafeFunction queue depth for utun poll (must match ingress buffer). */
-export const TUN_POLL_TSFN_QUEUE_DEPTH = MAX_TUN_INGRESS_QUEUE;
+/** Max utun packets buffered on the JS side before TLS write. */
+export const MAX_TUN_INGRESS_QUEUE = 256;
+/** Max ThreadSafeFunction queue depth (native addon limit). */
+export const MAX_TUN_POLL_TSFN_QUEUE_DEPTH = 64;
+/** ThreadSafeFunction queue depth passed to {@link TunTap.startPolling}. */
+export const TUN_POLL_TSFN_QUEUE_DEPTH = MAX_TUN_POLL_TSFN_QUEUE_DEPTH;
+/** Yield device→TUN loop periodically so utun poll callbacks can run. */
+export const DEVICE_PUMP_YIELD_EVERY_FRAMES = 64;
 
 export const CD_TUNNEL_MAGIC = 'CDTunnel';
 export const CD_TUNNEL_MAGIC_SIZE = 8;

--- a/src/tunnel/debug-log.ts
+++ b/src/tunnel/debug-log.ts
@@ -1,14 +1,22 @@
 import {log} from '../logger.js';
 
-/** Wedge diagnostics — set TUNTAP_DEBUG_FORWARD=1 on the tunnel process. */
-export const TUNTAP_FORWARD_DEBUG =
-  process.env.TUNTAP_DEBUG_FORWARD === '1' || process.env.TUNTAP_DEBUG_FORWARD === 'true';
+/** Tunnel debug logging — set APPIUM_TUNTAP_DEBUG=1 on the tunnel process. */
+export const APPIUM_TUNTAP_DEBUG =
+  process.env.APPIUM_TUNTAP_DEBUG === '1' || process.env.APPIUM_TUNTAP_DEBUG === 'true';
 
 let seq = 0;
 
-/** Log a numbered tunnel forward diagnostic when {@link TUNTAP_FORWARD_DEBUG} is enabled. */
+/** {@link log.debug} when {@link APPIUM_TUNTAP_DEBUG} is enabled. */
+export function tunDebug(...args: Parameters<typeof log.debug>): void {
+  if (!APPIUM_TUNTAP_DEBUG) {
+    return;
+  }
+  log.debug(...args);
+}
+
+/** Log a numbered tunnel forward diagnostic when {@link APPIUM_TUNTAP_DEBUG} is enabled. */
 export function fwdDebug(event: string, detail?: Record<string, string | number | boolean>): void {
-  if (!TUNTAP_FORWARD_DEBUG) {
+  if (!APPIUM_TUNTAP_DEBUG) {
     return;
   }
   seq += 1;
@@ -21,7 +29,7 @@ export function fwdDebug(event: string, detail?: Record<string, string | number 
   log.info(`[fwd] ${parts.join(' ')}`);
 }
 
-/** Summarize reassembly buffer state for forward debug logs. */
+/** Summarize reassembly buffer state for debug logs. */
 export function fwdBufferState(buffer: Buffer): {
   buf: number;
   tailKind: string;

--- a/src/tunnel/device-to-tun-pump.ts
+++ b/src/tunnel/device-to-tun-pump.ts
@@ -1,0 +1,215 @@
+import type {Socket} from 'node:net';
+import {Buffer} from 'node:buffer';
+
+import type {TunTap} from '../TunTap.js';
+import {appendBuffer} from './buffer-utils.js';
+import {fwdDebug} from './forward-debug.js';
+import {IPV6_HEADER_SIZE, IPV6_VERSION} from './constants.js';
+
+export type DeviceToTunProgressHook = () => void;
+
+/**
+ * pymobiledevice3 sock_read_task-style device→TUN forwarding: read one exact
+ * IPv6 frame from the socket, write to TUN, repeat. Yields only when TUN write
+ * blocks (via notifyTunWritable from the TUN→device pump).
+ */
+export class DeviceToTunPump {
+  private cancelled = false;
+  private running = false;
+  private buffer: Buffer = Buffer.alloc(0);
+  private frameWaiter: ((packet: Buffer) => void) | null = null;
+  private frameReject: ((err: Error) => void) | null = null;
+  private tunWritableWaiter: (() => void) | null = null;
+  private loopPromise: Promise<void> | null = null;
+  private fwdFrames = 0;
+  private deviceIngressPaused = false;
+
+  constructor(
+    private readonly onFrameWritten?: DeviceToTunProgressHook,
+  ) {}
+
+  start(deviceConn: Socket, tun: TunTap): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.cancelled = false;
+
+    deviceConn.on('data', (chunk: Buffer) => this.onDeviceData(chunk));
+
+    fwdDebug('device-pump-start', {});
+    this.loopPromise = this.runLoop(deviceConn, tun);
+  }
+
+  notifyTunWritable(): void {
+    const waiter = this.tunWritableWaiter;
+    if (waiter) {
+      this.tunWritableWaiter = null;
+      waiter();
+    }
+  }
+
+  async stop(): Promise<void> {
+    this.cancelled = true;
+    if (this.frameReject) {
+      this.frameReject(new Error('device pump cancelled'));
+      this.frameReject = null;
+    }
+    this.frameWaiter = null;
+    this.tunWritableWaiter = null;
+    if (this.loopPromise) {
+      await this.loopPromise.catch(() => undefined);
+      this.loopPromise = null;
+    }
+    this.buffer = Buffer.alloc(0);
+    this.running = false;
+  }
+
+  private onDeviceData(chunk: Buffer): void {
+    if (this.cancelled || chunk.length === 0) {
+      return;
+    }
+    this.buffer = appendBuffer(this.buffer, chunk);
+    this.tryDeliverFrame();
+  }
+
+  private tryDeliverFrame(): void {
+    const waiter = this.frameWaiter;
+    if (!waiter) {
+      return;
+    }
+
+    const taken = takeOneIpv6Frame(this.buffer);
+    if (taken.kind === 'incomplete' || taken.kind === 'resync') {
+      if (taken.kind === 'resync') {
+        this.buffer = this.buffer.subarray(1);
+        this.tryDeliverFrame();
+      }
+      return;
+    }
+
+    this.buffer = shrinkBuffer(this.buffer, taken.length);
+    this.frameWaiter = null;
+    this.frameReject = null;
+    waiter(taken.packet);
+  }
+
+  private readOneFrame(): Promise<Buffer> {
+    if (this.cancelled) {
+      return Promise.reject(new Error('device pump cancelled'));
+    }
+
+    const taken = takeOneIpv6Frame(this.buffer);
+    if (taken.kind === 'frame') {
+      this.buffer = shrinkBuffer(this.buffer, taken.length);
+      return Promise.resolve(taken.packet);
+    }
+    if (taken.kind === 'resync') {
+      this.buffer = this.buffer.subarray(1);
+      return this.readOneFrame();
+    }
+
+    return new Promise((resolve, reject) => {
+      this.frameWaiter = resolve;
+      this.frameReject = reject;
+    });
+  }
+
+  private pauseDeviceIngress(deviceConn: Socket): void {
+    if (this.deviceIngressPaused || deviceConn.destroyed) {
+      return;
+    }
+    this.deviceIngressPaused = true;
+    deviceConn.pause();
+    fwdDebug('ingress-pause', {reason: 'tun-write-blocked', buf: this.buffer.length});
+  }
+
+  private resumeDeviceIngress(deviceConn: Socket): void {
+    if (!this.deviceIngressPaused || deviceConn.destroyed) {
+      return;
+    }
+    this.deviceIngressPaused = false;
+    deviceConn.resume();
+    fwdDebug('ingress-resume', {buf: this.buffer.length});
+  }
+
+  private waitTunWritable(): Promise<void> {
+    if (this.cancelled) {
+      return Promise.reject(new Error('device pump cancelled'));
+    }
+    return new Promise((resolve) => {
+      this.tunWritableWaiter = resolve;
+    });
+  }
+
+  private async writeFrameToTun(
+    deviceConn: Socket,
+    tun: TunTap,
+    packet: Buffer,
+  ): Promise<void> {
+    while (!this.cancelled) {
+      const bytesWritten = tun.write(packet);
+      if (bytesWritten > 0) {
+        if (this.deviceIngressPaused) {
+          this.resumeDeviceIngress(deviceConn);
+        }
+        return;
+      }
+      this.pauseDeviceIngress(deviceConn);
+      fwdDebug('tun-write-blocked', {frameLen: packet.length, buf: this.buffer.length});
+      await this.waitTunWritable();
+    }
+  }
+
+  private async runLoop(deviceConn: Socket, tun: TunTap): Promise<void> {
+    try {
+      while (!this.cancelled && !deviceConn.destroyed) {
+        const packet = await this.readOneFrame();
+        if (this.cancelled) {
+          break;
+        }
+        await this.writeFrameToTun(deviceConn, tun, packet);
+        this.fwdFrames += 1;
+        if (this.fwdFrames === 1 || this.fwdFrames % 200 === 0) {
+          fwdDebug('device-pump-write', {len: packet.length, frames: this.fwdFrames});
+        }
+        this.onFrameWritten?.();
+      }
+    } catch {
+      // stop() rejected a pending readOneFrame()
+    }
+    fwdDebug('device-pump-stop', {frames: this.fwdFrames});
+  }
+}
+
+function takeOneIpv6Frame(
+  buffer: Buffer,
+): {kind: 'frame'; packet: Buffer; length: number} | {kind: 'incomplete'} | {kind: 'resync'} {
+  if (buffer.length < IPV6_HEADER_SIZE) {
+    return {kind: 'incomplete'};
+  }
+
+  const version = (buffer[0] >> 4) & 0x0f;
+  if (version !== IPV6_VERSION) {
+    return {kind: 'resync'};
+  }
+
+  const payloadLength = buffer.readUInt16BE(4);
+  const length = IPV6_HEADER_SIZE + payloadLength;
+  if (buffer.length < length) {
+    return {kind: 'incomplete'};
+  }
+
+  return {
+    kind: 'frame',
+    packet: buffer.subarray(0, length),
+    length,
+  };
+}
+
+function shrinkBuffer(buffer: Buffer, consumed: number): Buffer {
+  if (consumed >= buffer.length) {
+    return Buffer.alloc(0);
+  }
+  return Buffer.from(buffer.subarray(consumed));
+}

--- a/src/tunnel/device-to-tun-pump.ts
+++ b/src/tunnel/device-to-tun-pump.ts
@@ -3,7 +3,7 @@ import {Buffer} from 'node:buffer';
 
 import type {TunTap} from '../TunTap.js';
 import {appendBuffer} from './buffer-utils.js';
-import {fwdDebug} from './forward-debug.js';
+import {fwdDebug} from './debug-log.js';
 import {
   IPV6_HEADER_SIZE,
   IPV6_VERSION,

--- a/src/tunnel/device-to-tun-pump.ts
+++ b/src/tunnel/device-to-tun-pump.ts
@@ -4,14 +4,18 @@ import {Buffer} from 'node:buffer';
 import type {TunTap} from '../TunTap.js';
 import {appendBuffer} from './buffer-utils.js';
 import {fwdDebug} from './forward-debug.js';
-import {IPV6_HEADER_SIZE, IPV6_VERSION, MAX_DEVICE_INGRESS_BUFFER} from './constants.js';
+import {
+  IPV6_HEADER_SIZE,
+  IPV6_VERSION,
+  MAX_DEVICE_INGRESS_BUFFER,
+  DEVICE_PUMP_YIELD_EVERY_FRAMES,
+} from './constants.js';
 
 export type DeviceToTunProgressHook = () => void;
 
 /**
- * pymobiledevice3 sock_read_task-style device→TUN forwarding: read one exact
- * IPv6 frame from the socket, write to TUN, repeat. Yields only when TUN write
- * blocks (via notifyTunWritable from the TUN→device pump).
+ * Device→TUN forwarding: read one exact IPv6 frame from the socket, write to TUN,
+ * repeat. Yields only when TUN write blocks (via notifyTunWritable from the TUN→device pump).
  */
 export class DeviceToTunPump {
   private cancelled = false;
@@ -190,9 +194,8 @@ export class DeviceToTunPump {
         this.maybeResumeDeviceIngress();
         return;
       }
-      // pymobiledevice3 blocks in sock_read_task on tun.write() without pausing
-      // the TLS stream — keep reading into the reassembly buffer while waiting
-      // for TUN→device progress to free utun capacity.
+      // Block on tun.write() without pausing the TLS stream — keep reading into the
+      // reassembly buffer while waiting for TUN→device progress to free utun capacity.
       fwdDebug('tun-write-blocked', {frameLen: packet.length, buf: this.buffer.length});
       await this.waitTunWritable();
     }
@@ -211,7 +214,9 @@ export class DeviceToTunPump {
           fwdDebug('device-pump-write', {len: packet.length, frames: this.fwdFrames});
         }
         this.onFrameWritten?.();
-        await new Promise((resolve) => setImmediate(resolve));
+        if (this.fwdFrames % DEVICE_PUMP_YIELD_EVERY_FRAMES === 0) {
+          await new Promise((resolve) => setImmediate(resolve));
+        }
       }
     } catch {
       // stop() rejected a pending readOneFrame()

--- a/src/tunnel/device-to-tun-pump.ts
+++ b/src/tunnel/device-to-tun-pump.ts
@@ -43,25 +43,6 @@ export class DeviceToTunPump {
     this.loopPromise = this.runLoop(deviceConn, tun);
   }
 
-  private enqueueDeviceData(chunk: Buffer): void {
-    if (this.cancelled || chunk.length === 0) {
-      return;
-    }
-    this.pendingDeviceChunks.push(chunk);
-    if (this.deviceDrainScheduled) {
-      return;
-    }
-    this.deviceDrainScheduled = true;
-    setImmediate(() => {
-      this.deviceDrainScheduled = false;
-      const chunks = this.pendingDeviceChunks;
-      this.pendingDeviceChunks = [];
-      for (const pending of chunks) {
-        this.onDeviceData(pending);
-      }
-    });
-  }
-
   notifyTunWritable(): void {
     const waiter = this.tunWritableWaiter;
     if (waiter) {
@@ -85,6 +66,25 @@ export class DeviceToTunPump {
     this.buffer = Buffer.alloc(0);
     this.deviceConn = null;
     this.running = false;
+  }
+
+  private enqueueDeviceData(chunk: Buffer): void {
+    if (this.cancelled || chunk.length === 0) {
+      return;
+    }
+    this.pendingDeviceChunks.push(chunk);
+    if (this.deviceDrainScheduled) {
+      return;
+    }
+    this.deviceDrainScheduled = true;
+    setImmediate(() => {
+      this.deviceDrainScheduled = false;
+      const chunks = this.pendingDeviceChunks;
+      this.pendingDeviceChunks = [];
+      for (const pending of chunks) {
+        this.onDeviceData(pending);
+      }
+    });
   }
 
   private onDeviceData(chunk: Buffer): void {

--- a/src/tunnel/device-to-tun-pump.ts
+++ b/src/tunnel/device-to-tun-pump.ts
@@ -4,7 +4,7 @@ import {Buffer} from 'node:buffer';
 import type {TunTap} from '../TunTap.js';
 import {appendBuffer} from './buffer-utils.js';
 import {fwdDebug} from './forward-debug.js';
-import {IPV6_HEADER_SIZE, IPV6_VERSION} from './constants.js';
+import {IPV6_HEADER_SIZE, IPV6_VERSION, MAX_DEVICE_INGRESS_BUFFER} from './constants.js';
 
 export type DeviceToTunProgressHook = () => void;
 
@@ -23,10 +23,11 @@ export class DeviceToTunPump {
   private loopPromise: Promise<void> | null = null;
   private fwdFrames = 0;
   private deviceIngressPaused = false;
+  private deviceConn: Socket | null = null;
+  private pendingDeviceChunks: Buffer[] = [];
+  private deviceDrainScheduled = false;
 
-  constructor(
-    private readonly onFrameWritten?: DeviceToTunProgressHook,
-  ) {}
+  constructor(private readonly onFrameWritten?: DeviceToTunProgressHook) {}
 
   start(deviceConn: Socket, tun: TunTap): void {
     if (this.running) {
@@ -34,11 +35,31 @@ export class DeviceToTunPump {
     }
     this.running = true;
     this.cancelled = false;
+    this.deviceConn = deviceConn;
 
-    deviceConn.on('data', (chunk: Buffer) => this.onDeviceData(chunk));
+    deviceConn.on('data', (chunk: Buffer) => this.enqueueDeviceData(chunk));
 
     fwdDebug('device-pump-start', {});
     this.loopPromise = this.runLoop(deviceConn, tun);
+  }
+
+  private enqueueDeviceData(chunk: Buffer): void {
+    if (this.cancelled || chunk.length === 0) {
+      return;
+    }
+    this.pendingDeviceChunks.push(chunk);
+    if (this.deviceDrainScheduled) {
+      return;
+    }
+    this.deviceDrainScheduled = true;
+    setImmediate(() => {
+      this.deviceDrainScheduled = false;
+      const chunks = this.pendingDeviceChunks;
+      this.pendingDeviceChunks = [];
+      for (const pending of chunks) {
+        this.onDeviceData(pending);
+      }
+    });
   }
 
   notifyTunWritable(): void {
@@ -62,6 +83,7 @@ export class DeviceToTunPump {
       this.loopPromise = null;
     }
     this.buffer = Buffer.alloc(0);
+    this.deviceConn = null;
     this.running = false;
   }
 
@@ -70,7 +92,25 @@ export class DeviceToTunPump {
       return;
     }
     this.buffer = appendBuffer(this.buffer, chunk);
+    if (
+      this.deviceConn &&
+      this.buffer.length > MAX_DEVICE_INGRESS_BUFFER &&
+      !this.deviceIngressPaused
+    ) {
+      this.pauseDeviceIngress(this.deviceConn, 'max-buffer');
+    }
     this.tryDeliverFrame();
+  }
+
+  private maybeResumeDeviceIngress(): void {
+    if (
+      !this.deviceConn ||
+      !this.deviceIngressPaused ||
+      this.buffer.length > MAX_DEVICE_INGRESS_BUFFER
+    ) {
+      return;
+    }
+    this.resumeDeviceIngress(this.deviceConn);
   }
 
   private tryDeliverFrame(): void {
@@ -92,6 +132,7 @@ export class DeviceToTunPump {
     this.frameWaiter = null;
     this.frameReject = null;
     waiter(taken.packet);
+    this.maybeResumeDeviceIngress();
   }
 
   private readOneFrame(): Promise<Buffer> {
@@ -115,13 +156,13 @@ export class DeviceToTunPump {
     });
   }
 
-  private pauseDeviceIngress(deviceConn: Socket): void {
+  private pauseDeviceIngress(deviceConn: Socket, reason: string): void {
     if (this.deviceIngressPaused || deviceConn.destroyed) {
       return;
     }
     this.deviceIngressPaused = true;
     deviceConn.pause();
-    fwdDebug('ingress-pause', {reason: 'tun-write-blocked', buf: this.buffer.length});
+    fwdDebug('ingress-pause', {reason, buf: this.buffer.length});
   }
 
   private resumeDeviceIngress(deviceConn: Socket): void {
@@ -142,20 +183,16 @@ export class DeviceToTunPump {
     });
   }
 
-  private async writeFrameToTun(
-    deviceConn: Socket,
-    tun: TunTap,
-    packet: Buffer,
-  ): Promise<void> {
+  private async writeFrameToTun(deviceConn: Socket, tun: TunTap, packet: Buffer): Promise<void> {
     while (!this.cancelled) {
       const bytesWritten = tun.write(packet);
       if (bytesWritten > 0) {
-        if (this.deviceIngressPaused) {
-          this.resumeDeviceIngress(deviceConn);
-        }
+        this.maybeResumeDeviceIngress();
         return;
       }
-      this.pauseDeviceIngress(deviceConn);
+      // pymobiledevice3 blocks in sock_read_task on tun.write() without pausing
+      // the TLS stream — keep reading into the reassembly buffer while waiting
+      // for TUN→device progress to free utun capacity.
       fwdDebug('tun-write-blocked', {frameLen: packet.length, buf: this.buffer.length});
       await this.waitTunWritable();
     }
@@ -174,6 +211,7 @@ export class DeviceToTunPump {
           fwdDebug('device-pump-write', {len: packet.length, frames: this.fwdFrames});
         }
         this.onFrameWritten?.();
+        await new Promise((resolve) => setImmediate(resolve));
       }
     } catch {
       // stop() rejected a pending readOneFrame()
@@ -211,5 +249,5 @@ function shrinkBuffer(buffer: Buffer, consumed: number): Buffer {
   if (consumed >= buffer.length) {
     return Buffer.alloc(0);
   }
-  return Buffer.from(buffer.subarray(consumed));
+  return buffer.subarray(consumed);
 }

--- a/src/tunnel/device-to-tun-pump.ts
+++ b/src/tunnel/device-to-tun-pump.ts
@@ -58,10 +58,13 @@ export class DeviceToTunPump {
   async stop(): Promise<void> {
     this.cancelled = true;
     if (this.frameReject) {
-      this.frameReject(new Error('device pump cancelled'));
-      this.frameReject = null;
+      this.frameReject(new Error(DEVICE_PUMP_CANCELLED));
+    }
+    if (this.tunWritableWaiter) {
+      this.tunWritableWaiter();
     }
     this.frameWaiter = null;
+    this.frameReject = null;
     this.tunWritableWaiter = null;
     if (this.loopPromise) {
       await this.loopPromise.catch(() => undefined);
@@ -141,7 +144,7 @@ export class DeviceToTunPump {
 
   private readOneFrame(): Promise<Buffer> {
     if (this.cancelled) {
-      return Promise.reject(new Error('device pump cancelled'));
+      return Promise.reject(new Error(DEVICE_PUMP_CANCELLED));
     }
 
     const taken = takeOneIpv6Frame(this.buffer);
@@ -180,7 +183,7 @@ export class DeviceToTunPump {
 
   private waitTunWritable(): Promise<void> {
     if (this.cancelled) {
-      return Promise.reject(new Error('device pump cancelled'));
+      return Promise.reject(new Error(DEVICE_PUMP_CANCELLED));
     }
     return new Promise((resolve) => {
       this.tunWritableWaiter = resolve;
@@ -218,11 +221,19 @@ export class DeviceToTunPump {
           await new Promise((resolve) => setImmediate(resolve));
         }
       }
-    } catch {
-      // stop() rejected a pending readOneFrame()
+    } catch (err) {
+      if (!isPumpCancelled(err)) {
+        throw err;
+      }
     }
     fwdDebug('device-pump-stop', {frames: this.fwdFrames});
   }
+}
+
+const DEVICE_PUMP_CANCELLED = 'device pump cancelled';
+
+function isPumpCancelled(err: unknown): boolean {
+  return err instanceof Error && err.message === DEVICE_PUMP_CANCELLED;
 }
 
 function takeOneIpv6Frame(

--- a/src/tunnel/forward-debug.ts
+++ b/src/tunnel/forward-debug.ts
@@ -2,15 +2,11 @@ import {log} from '../logger.js';
 
 /** Wedge diagnostics — set TUNTAP_DEBUG_FORWARD=1 on the tunnel process. */
 export const TUNTAP_FORWARD_DEBUG =
-  process.env.TUNTAP_DEBUG_FORWARD === '1' ||
-  process.env.TUNTAP_DEBUG_FORWARD === 'true';
+  process.env.TUNTAP_DEBUG_FORWARD === '1' || process.env.TUNTAP_DEBUG_FORWARD === 'true';
 
 let seq = 0;
 
-export function fwdDebug(
-  event: string,
-  detail?: Record<string, string | number | boolean>,
-): void {
+export function fwdDebug(event: string, detail?: Record<string, string | number | boolean>): void {
   if (!TUNTAP_FORWARD_DEBUG) {
     return;
   }

--- a/src/tunnel/forward-debug.ts
+++ b/src/tunnel/forward-debug.ts
@@ -1,0 +1,47 @@
+import {log} from '../logger.js';
+
+/** Wedge diagnostics — set TUNTAP_DEBUG_FORWARD=1 on the tunnel process. */
+export const TUNTAP_FORWARD_DEBUG =
+  process.env.TUNTAP_DEBUG_FORWARD === '1' ||
+  process.env.TUNTAP_DEBUG_FORWARD === 'true';
+
+let seq = 0;
+
+export function fwdDebug(
+  event: string,
+  detail?: Record<string, string | number | boolean>,
+): void {
+  if (!TUNTAP_FORWARD_DEBUG) {
+    return;
+  }
+  seq += 1;
+  const parts = [`#${seq}`, event];
+  if (detail) {
+    for (const [key, value] of Object.entries(detail)) {
+      parts.push(`${key}=${value}`);
+    }
+  }
+  log.info(`[fwd] ${parts.join(' ')}`);
+}
+
+export function fwdBufferState(buffer: Buffer): {
+  buf: number;
+  tailKind: string;
+} {
+  if (buffer.length === 0) {
+    return {buf: 0, tailKind: 'empty'};
+  }
+  if (buffer.length < 40) {
+    return {buf: buffer.length, tailKind: 'short'};
+  }
+  const version = (buffer[0] >> 4) & 0x0f;
+  if (version !== 6) {
+    return {buf: buffer.length, tailKind: 'resync-needed'};
+  }
+  const payloadLength = buffer.readUInt16BE(4);
+  const frameLength = 40 + payloadLength;
+  if (buffer.length >= frameLength) {
+    return {buf: buffer.length, tailKind: 'has-complete-frame'};
+  }
+  return {buf: buffer.length, tailKind: 'incomplete-tail'};
+}

--- a/src/tunnel/forward-debug.ts
+++ b/src/tunnel/forward-debug.ts
@@ -6,6 +6,7 @@ export const TUNTAP_FORWARD_DEBUG =
 
 let seq = 0;
 
+/** Log a numbered tunnel forward diagnostic when {@link TUNTAP_FORWARD_DEBUG} is enabled. */
 export function fwdDebug(event: string, detail?: Record<string, string | number | boolean>): void {
   if (!TUNTAP_FORWARD_DEBUG) {
     return;
@@ -20,6 +21,7 @@ export function fwdDebug(event: string, detail?: Record<string, string | number 
   log.info(`[fwd] ${parts.join(' ')}`);
 }
 
+/** Summarize reassembly buffer state for forward debug logs. */
 export function fwdBufferState(buffer: Buffer): {
   buf: number;
   tailKind: string;

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -17,7 +17,7 @@ import {
   IPPROTO_UDP,
 } from './constants.js';
 import {appendBuffer} from './buffer-utils.js';
-import {fwdBufferState, fwdDebug} from './forward-debug.js';
+import {fwdBufferState, fwdDebug, tunDebug} from './debug-log.js';
 import {TunToDevicePump} from './tun-to-device-pump.js';
 import {DeviceToTunPump} from './device-to-tun-pump.js';
 import type {
@@ -116,7 +116,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
   async setupInterface(
     tunnelInfo: TunnelInfo,
   ): Promise<{name: string; mtu: number; interface: TunTap}> {
-    log.debug(`Setting up tunnel with parameters:`, tunnelInfo);
+    tunDebug(`Setting up tunnel with parameters:`, tunnelInfo);
 
     try {
       this.tun = new TunTap();
@@ -126,7 +126,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
         throw new Error('Failed to open TUN device');
       }
 
-      log.debug(`Opened TUN device: ${this.tun.name}`);
+      tunDebug(`Opened TUN device: ${this.tun.name}`);
 
       this.mtu = tunnelInfo.clientParameters.mtu;
 
@@ -139,7 +139,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
       // Add route for the server address
       await this.tun.addRoute(`${tunnelInfo.serverAddress}/128`);
 
-      log.debug(
+      tunDebug(
         `Configured TUN interface ${this.tun.name} with address ${tunnelInfo.clientParameters.address} and MTU ${tunnelInfo.clientParameters.mtu}`,
       );
 
@@ -174,7 +174,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
     }
 
     this.deviceConn = deviceConn;
-    log.debug(`Starting bidirectional data forwarding for ${this.tun.name}`);
+    tunDebug(`Starting bidirectional data forwarding for ${this.tun.name}`);
 
     deviceConn.setNoDelay(true);
     deviceConn.setKeepAlive(true, 1000);
@@ -221,7 +221,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
 
     // Listen for device connection close
     deviceConn.on('close', async () => {
-      log.debug('Device connection closed, stopping tunnel');
+      tunDebug('Device connection closed, stopping tunnel');
       try {
         await this.stop();
       } catch (err) {
@@ -363,7 +363,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
     }
 
     const {src, dst} = ipv6Endpoints(packet);
-    log.debug(`Device → TUN: ${bytesWritten} bytes, IPv6 src=${src}, dst=${dst}`);
+    tunDebug(`Device → TUN: ${bytesWritten} bytes, IPv6 src=${src}, dst=${dst}`);
     this.tapL4Packet(packet, nextHeader, src, dst);
     return bytesWritten;
   }
@@ -374,19 +374,19 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
     if (nextHeader === IPPROTO_UDP) {
       packetData = parseUdpPacketData(packet, src, dst);
       if (!packetData) {
-        log.debug('UDP payload too short, not emitting event.');
+        tunDebug('UDP payload too short, not emitting event.');
       } else {
-        log.debug(`UDP packet detected: payload length=${packetData.payload.length}`);
+        tunDebug(`UDP packet detected: payload length=${packetData.payload.length}`);
       }
     } else if (nextHeader === IPPROTO_TCP) {
       packetData = parseTcpPacketData(packet, src, dst);
       if (!packetData) {
-        log.debug('TCP packet too short or malformed, skipping.');
+        tunDebug('TCP packet too short or malformed, skipping.');
       } else {
-        log.debug(`TCP packet detected: payload length=${packetData.payload.length}`);
+        tunDebug(`TCP packet detected: payload length=${packetData.payload.length}`);
       }
     } else {
-      log.debug('Packet is not UDP or TCP (nextHeader !== 17 and !== 6)');
+      tunDebug('Packet is not UDP or TCP (nextHeader !== 17 and !== 6)');
     }
 
     if (packetData) {
@@ -403,7 +403,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
         log.error('Error in packet consumer:', err);
       }
     }
-    log.debug(`Emitted data event for ${packetData.protocol} packet`);
+    tunDebug(`Emitted data event for ${packetData.protocol} packet`);
   }
 
   private startDeviceToTunPump(deviceConn: Socket): void {
@@ -427,11 +427,11 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
       tapOn
         ? (data) => {
             if (data.length >= IPV6_HEADER_SIZE) {
-              log.debug(
+              tunDebug(
                 `TUN → Device: ${data.length} bytes, IPv6 src=${formatIPv6Address(data.subarray(8, 24))}, dst=${formatIPv6Address(data.subarray(24, 40))}`,
               );
             } else {
-              log.debug(`TUN → Device: ${data.length} bytes (too small for IPv6 header)`);
+              tunDebug(`TUN → Device: ${data.length} bytes (too small for IPv6 header)`);
             }
           }
         : undefined,
@@ -451,7 +451,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
 
   private async _performStop(): Promise<void> {
     const tunName = this.tun ? this.tun.name : 'unknown';
-    log.debug(`Stopping tunnel manager for ${tunName}`);
+    tunDebug(`Stopping tunnel manager for ${tunName}`);
 
     // Signal cancellation
     this.cancelled = true;
@@ -491,7 +491,7 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
       this.tun = null;
     }
 
-    log.debug(`Tunnel for ${tunName} closed successfully`);
+    tunDebug(`Tunnel for ${tunName} closed successfully`);
   }
 }
 
@@ -508,7 +508,7 @@ export async function exchangeCoreTunnelParameters(socket: Socket): Promise<Tunn
   });
   const message = encodeCdTunnelMessage(requestJson);
 
-  log.debug(
+  tunDebug(
     `Sending CDTunnel packet: magic=${CD_TUNNEL_MAGIC}, length=${message.length - CD_TUNNEL_HEADER_SIZE}, body=${requestJson}`,
   );
 
@@ -530,18 +530,18 @@ export async function connectToTunnelLockdown(
   try {
     // Exchange tunnel parameters with the device
     const tunnelInfo = await exchangeCoreTunnelParameters(secureServiceSocket);
-    log.debug('Tunnel parameters exchanged:', tunnelInfo);
+    tunDebug('Tunnel parameters exchanged:', tunnelInfo);
 
     // Setup tunnel interface
     const tunInterfaceInfo = await tunnelManager.setupInterface(tunnelInfo);
-    log.debug('Tunnel interface set up:', tunInterfaceInfo.name);
+    tunDebug('Tunnel interface set up:', tunInterfaceInfo.name);
 
     // Start bidirectional forwarding
     tunnelManager.startForwarding(secureServiceSocket);
 
     // Create close function
     const closeFunc = async () => {
-      log.debug('Closing tunnel connection');
+      tunDebug('Closing tunnel connection');
       await tunnelManager.stop();
 
       if (!secureServiceSocket.destroyed) {
@@ -622,12 +622,12 @@ function readCdTunnelResponse(socket: Socket, timeoutMs: number): Promise<Tunnel
     };
 
     const onData = (chunk: Buffer) => {
-      log.debug('Received data chunk:', chunk.length, 'bytes');
+      tunDebug('Received data chunk:', chunk.length, 'bytes');
       buffer = appendBuffer(buffer, chunk);
 
       if (buffer.length >= CD_TUNNEL_HEADER_SIZE) {
         const payloadLength = buffer.readUInt16BE(CD_TUNNEL_MAGIC_SIZE);
-        log.debug(
+        tunDebug(
           'Expected total packet length:',
           CD_TUNNEL_HEADER_SIZE + payloadLength,
           'current buffer:',
@@ -644,7 +644,7 @@ function readCdTunnelResponse(socket: Socket, timeoutMs: number): Promise<Tunnel
         return;
       }
 
-      log.debug('Parsed CDTunnel response:', result.value);
+      tunDebug('Parsed CDTunnel response:', result.value);
       finish(() => resolve(result.value));
     };
 
@@ -654,9 +654,9 @@ function readCdTunnelResponse(socket: Socket, timeoutMs: number): Promise<Tunnel
     };
 
     const onEnd = () => {
-      log.debug('Connection ended');
+      tunDebug('Connection ended');
       if (buffer.length > 0) {
-        log.debug('Buffer at end:', buffer.toString('hex'));
+        tunDebug('Buffer at end:', buffer.toString('hex'));
       }
       finish(() => reject(new Error('Connection closed before receiving complete response')));
     };

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -10,17 +10,16 @@ import {
   CD_TUNNEL_MAGIC,
   CD_TUNNEL_MAGIC_SIZE,
   CD_TUNNEL_MTU,
-  DEFAULT_TUN_POLL_QUEUE_DEPTH,
-  FAST_TUN_POLL_QUEUE_DEPTH,
   IPV6_HEADER_SIZE,
-  LARGE_TUN_POLL_BUFFER,
   MAX_DEVICE_INGRESS_BUFFER,
-  MAX_TUN_POLL_BUFFER,
   IPV6_VERSION,
   IPPROTO_TCP,
   IPPROTO_UDP,
 } from './constants.js';
 import {appendBuffer} from './buffer-utils.js';
+import {fwdBufferState, fwdDebug} from './forward-debug.js';
+import {TunToDevicePump} from './tun-to-device-pump.js';
+import {DeviceToTunPump} from './device-to-tun-pump.js';
 import type {
   CdTunnelParseResult,
   Ipv6Frame,
@@ -43,8 +42,10 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
   private readonly packetConsumers: Set<PacketConsumer> = new Set();
   private deviceConn: Socket | null = null;
   private cleanupPromise: Promise<void> | null = null;
-  private tunReadPausedForBackpressure = false;
-  private deviceIngressPausedForTun = false;
+  private tunToDevicePump: TunToDevicePump | null = null;
+  private deviceToTunPump: DeviceToTunPump | null = null;
+  private deviceIngressPaused = false;
+  private fwdDeviceDataChunks = 0;
 
   /**
    * Register a listener for parsed tunnel packets (in addition to the `data` event).
@@ -178,29 +179,45 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
     deviceConn.setNoDelay(true);
     deviceConn.setKeepAlive(true, 1000);
 
-    // Handle data from the device connection
-    deviceConn.on('data', (data: Buffer) => {
-      if (this.cancelled) {
-        return;
-      }
-
-      try {
-        this.buffer = appendBuffer(this.buffer, data);
-
-        if (this.buffer.length > MAX_DEVICE_INGRESS_BUFFER) {
-          this.pauseDeviceIngress();
+    if (this.hasPacketTap()) {
+      deviceConn.on('data', (data: Buffer) => {
+        if (this.cancelled) {
+          return;
         }
 
-        this.processBuffer();
-      } catch (err: any) {
-        if (!this.cancelled) {
-          log.error('Error processing device data:', err.message);
+        try {
+          this.fwdDeviceDataChunks += 1;
+          this.buffer = appendBuffer(this.buffer, data);
+
+          if (this.buffer.length > MAX_DEVICE_INGRESS_BUFFER) {
+            this.pauseDeviceIngress('max-buffer');
+          }
+
+          if (this.fwdDeviceDataChunks === 1 || this.fwdDeviceDataChunks % 200 === 0) {
+            fwdDebug('device-data', {
+              chunk: data.length,
+              ...fwdBufferState(this.buffer),
+              ingressPaused: this.deviceIngressPaused,
+              chunks: this.fwdDeviceDataChunks,
+            });
+          }
+
+          this.processBuffer('data');
+        } catch (err: any) {
+          if (!this.cancelled) {
+            log.error('Error processing device data:', err.message);
+          }
         }
-      }
+      });
+    } else {
+      this.startDeviceToTunPump(deviceConn);
+    }
+
+    deviceConn.on('drain', () => {
+      this.deviceToTunPump?.notifyTunWritable();
     });
 
-    // Set up TUN read loop
-    this.startTunReadLoop(deviceConn);
+    this.startTunToDevicePump(deviceConn);
 
     // Listen for device connection close
     deviceConn.on('close', async () => {
@@ -236,8 +253,34 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
     return this.packetConsumers.size > 0 || this.listenerCount('data') > 0;
   }
 
-  private processBuffer(): void {
+  private pauseDeviceIngress(reason: string): void {
+    if (this.deviceIngressPaused || !this.deviceConn || this.deviceConn.destroyed) {
+      return;
+    }
+    this.deviceIngressPaused = true;
+    this.deviceConn.pause();
+    fwdDebug('ingress-pause', {
+      reason,
+      ...fwdBufferState(this.buffer),
+    });
+  }
+
+  private resumeDeviceIngress(): void {
+    if (!this.deviceIngressPaused || !this.deviceConn || this.deviceConn.destroyed) {
+      return;
+    }
+    this.deviceIngressPaused = false;
+    this.deviceConn.resume();
+    fwdDebug('ingress-resume', {
+      ...fwdBufferState(this.buffer),
+    });
+  }
+
+  private processBuffer(trigger = 'unknown'): void {
     let offset = 0;
+    let tunWriteBlocked = false;
+    let framesWritten = 0;
+    const bufBefore = this.buffer.length;
 
     while (offset + IPV6_HEADER_SIZE <= this.buffer.length) {
       const frame = nextIpv6Frame(this.buffer, offset);
@@ -255,11 +298,22 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
       }
 
       try {
-        this.writeDeviceFrameToTun(this.tun, frame.packet, frame.nextHeader);
+        const bytesWritten = this.writeDeviceFrameToTun(this.tun, frame.packet, frame.nextHeader);
+        if (bytesWritten === 'blocked') {
+          tunWriteBlocked = true;
+          fwdDebug('tun-write-blocked', {
+            trigger,
+            frameLen: frame.length,
+            ...fwdBufferState(this.buffer),
+            ingressPaused: this.deviceIngressPaused,
+          });
+          break;
+        }
       } catch (err: any) {
         log.error(`Error writing to TUN: ${err.message}`);
       }
 
+      framesWritten += 1;
       offset += frame.length;
     }
 
@@ -271,45 +325,47 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
       }
     }
 
-    if (this.deviceIngressPausedForTun && this.shouldResumeDeviceIngress()) {
-      this.resumeDeviceIngress();
+    if (this.deviceIngressPaused) {
+      const mayResume =
+        !tunWriteBlocked &&
+        (this.buffer.length === 0 || this.buffer.length <= MAX_DEVICE_INGRESS_BUFFER / 2);
+      if (mayResume) {
+        this.resumeDeviceIngress();
+      } else if (tunWriteBlocked || framesWritten > 0 || bufBefore > 0) {
+        fwdDebug('process-buffer', {
+          trigger,
+          bufBefore,
+          bufAfter: this.buffer.length,
+          offset,
+          framesWritten,
+          tunWriteBlocked,
+          mayResume,
+          ingressPaused: this.deviceIngressPaused,
+          ...fwdBufferState(this.buffer),
+        });
+      }
     }
   }
 
-  private writeDeviceFrameToTun(tun: TunTap, packet: Buffer, nextHeader: number): void {
-    tun.write(packet);
+  private writeDeviceFrameToTun(
+    tun: TunTap,
+    packet: Buffer,
+    nextHeader: number,
+  ): number | 'blocked' {
+    const bytesWritten = tun.write(packet);
+    if (bytesWritten <= 0) {
+      this.pauseDeviceIngress('tun-write-blocked');
+      return 'blocked';
+    }
 
     if (!this.hasPacketTap()) {
-      return;
+      return bytesWritten;
     }
 
     const {src, dst} = ipv6Endpoints(packet);
-    log.debug(`Device → TUN: ${packet.length} bytes, IPv6 src=${src}, dst=${dst}`);
+    log.debug(`Device → TUN: ${bytesWritten} bytes, IPv6 src=${src}, dst=${dst}`);
     this.tapL4Packet(packet, nextHeader, src, dst);
-  }
-
-  private shouldResumeDeviceIngress(): boolean {
-    if (this.buffer.length === 0) {
-      return true;
-    }
-    // All complete frames were written; waiting on more socket bytes to finish the tail frame.
-    return nextIpv6Frame(this.buffer, 0).kind === 'incomplete';
-  }
-
-  private pauseDeviceIngress(): void {
-    if (this.deviceIngressPausedForTun || !this.deviceConn || this.deviceConn.destroyed) {
-      return;
-    }
-    this.deviceIngressPausedForTun = true;
-    this.deviceConn.pause();
-  }
-
-  private resumeDeviceIngress(): void {
-    if (!this.deviceIngressPausedForTun || !this.deviceConn || this.deviceConn.destroyed) {
-      return;
-    }
-    this.deviceIngressPausedForTun = false;
-    this.deviceConn.resume();
+    return bytesWritten;
   }
 
   private tapL4Packet(packet: Buffer, nextHeader: number, src: string, dst: string): void {
@@ -350,60 +406,47 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
     log.debug(`Emitted data event for ${packetData.protocol} packet`);
   }
 
-  private startTunReadLoop(deviceConn: Socket): void {
+  private startDeviceToTunPump(deviceConn: Socket): void {
+    if (!this.tun) {
+      return;
+    }
+
+    this.deviceToTunPump = new DeviceToTunPump();
+    this.deviceToTunPump.start(deviceConn, this.tun);
+  }
+
+  private startTunToDevicePump(deviceConn: Socket): void {
     if (!this.tun) {
       return;
     }
 
     const tapOn = this.hasPacketTap();
-    const pollBuffer = tapOn
-      ? this.mtu
-      : Math.min(MAX_TUN_POLL_BUFFER, Math.max(this.mtu, LARGE_TUN_POLL_BUFFER));
-    const queueDepth = tapOn ? DEFAULT_TUN_POLL_QUEUE_DEPTH : FAST_TUN_POLL_QUEUE_DEPTH;
-
-    this.tun.startPolling(
-      (data: Buffer) => {
-        if (this.cancelled || !data.length || deviceConn.destroyed) {
-          return;
+    this.tunToDevicePump = new TunToDevicePump(
+      this.tun,
+      this.mtu,
+      tapOn
+        ? (data) => {
+            if (data.length >= IPV6_HEADER_SIZE) {
+              log.debug(
+                `TUN → Device: ${data.length} bytes, IPv6 src=${formatIPv6Address(data.subarray(8, 24))}, dst=${formatIPv6Address(data.subarray(24, 40))}`,
+              );
+            } else {
+              log.debug(`TUN → Device: ${data.length} bytes (too small for IPv6 header)`);
+            }
+          }
+        : undefined,
+      () => {
+        this.deviceToTunPump?.notifyTunWritable();
+        if (this.deviceIngressPaused) {
+          fwdDebug('forward-progress', {
+            ingressPaused: this.deviceIngressPaused,
+            ...fwdBufferState(this.buffer),
+          });
+          this.processBuffer('forward-progress');
         }
-
-        if (tapOn && data.length >= IPV6_HEADER_SIZE) {
-          log.debug(
-            `TUN → Device: ${data.length} bytes, IPv6 src=${formatIPv6Address(data.subarray(8, 24))}, dst=${formatIPv6Address(data.subarray(24, 40))}`,
-          );
-        } else if (tapOn) {
-          log.debug(`TUN → Device: ${data.length} bytes (too small for IPv6 header)`);
-        }
-
-        this.writeTunPacketToDevice(deviceConn, data);
       },
-      pollBuffer,
-      queueDepth,
     );
-  }
-
-  private writeTunPacketToDevice(deviceConn: Socket, data: Buffer): void {
-    if (deviceConn.destroyed) {
-      return;
-    }
-
-    const canWriteMore = deviceConn.write(data);
-    if (canWriteMore || this.tunReadPausedForBackpressure || !this.tun) {
-      return;
-    }
-
-    this.tunReadPausedForBackpressure = true;
-    this.tun.pausePolling();
-
-    const onDrain = (): void => {
-      if (this.cancelled || deviceConn.destroyed) {
-        return;
-      }
-      this.tunReadPausedForBackpressure = false;
-      this.tun?.resumePolling();
-    };
-
-    deviceConn.once('drain', onDrain);
+    this.tunToDevicePump.start(deviceConn);
   }
 
   private async _performStop(): Promise<void> {
@@ -412,6 +455,16 @@ export class TunnelManager extends EventEmitter<TunnelManagerEvents> {
 
     // Signal cancellation
     this.cancelled = true;
+
+    if (this.tunToDevicePump) {
+      await this.tunToDevicePump.stop();
+      this.tunToDevicePump = null;
+    }
+
+    if (this.deviceToTunPump) {
+      await this.deviceToTunPump.stop();
+      this.deviceToTunPump = null;
+    }
 
     // Close device connection if exists
     if (this.deviceConn && !this.deviceConn.destroyed) {

--- a/src/tunnel/tun-to-device-pump.ts
+++ b/src/tunnel/tun-to-device-pump.ts
@@ -1,0 +1,147 @@
+import {once} from 'node:events';
+import type {Socket} from 'node:net';
+
+import type {TunTap} from '../TunTap.js';
+import {SEQUENTIAL_TUN_POLL_QUEUE_DEPTH} from './constants.js';
+import {fwdDebug} from './forward-debug.js';
+
+export type TunToDeviceProgressHook = () => void;
+
+/**
+ * pymobiledevice3-style TUN→device forwarding: read one packet, write, await
+ * drain when the socket needs it, then read the next.
+ */
+export class TunToDevicePump {
+  private cancelled = false;
+  private running = false;
+  private tunPacketWaiter: ((packet: Buffer) => void) | null = null;
+  private readReject: ((err: Error) => void) | null = null;
+  private drainAbort: AbortController | null = null;
+  private loopPromise: Promise<void> | null = null;
+  private fwdPumpPackets = 0;
+
+  constructor(
+    private readonly tun: TunTap,
+    private readonly mtu: number,
+    private readonly onPacketRead?: (data: Buffer) => void,
+    private readonly onForwardProgress?: TunToDeviceProgressHook,
+  ) {}
+
+  start(deviceConn: Socket): void {
+    if (this.running) {
+      return;
+    }
+    this.running = true;
+    this.cancelled = false;
+
+    this.tun.startPolling(
+      (data: Buffer) => this.onTunPollData(data),
+      this.mtu,
+      SEQUENTIAL_TUN_POLL_QUEUE_DEPTH,
+    );
+    this.tun.pausePolling();
+
+    fwdDebug('pump-start', {mtu: this.mtu, queueDepth: SEQUENTIAL_TUN_POLL_QUEUE_DEPTH});
+    this.loopPromise = this.runLoop(deviceConn);
+  }
+
+  async stop(): Promise<void> {
+    this.cancelled = true;
+    this.drainAbort?.abort();
+    this.drainAbort = null;
+    this.tun.pausePolling();
+    if (this.readReject) {
+      this.readReject(new Error('pump cancelled'));
+      this.readReject = null;
+    }
+    this.tunPacketWaiter = null;
+    if (this.loopPromise) {
+      await this.loopPromise.catch(() => undefined);
+      this.loopPromise = null;
+    }
+    this.running = false;
+  }
+
+  private onTunPollData(data: Buffer): void {
+    if (this.cancelled || !data.length) {
+      return;
+    }
+
+    this.tun.pausePolling();
+    this.onPacketRead?.(data);
+
+    const waiter = this.tunPacketWaiter;
+    if (waiter) {
+      this.tunPacketWaiter = null;
+      this.readReject = null;
+      waiter(data);
+    }
+  }
+
+  private readOnePacket(): Promise<Buffer> {
+    if (this.cancelled) {
+      return Promise.reject(new Error('pump cancelled'));
+    }
+    return new Promise((resolve, reject) => {
+      this.tunPacketWaiter = resolve;
+      this.readReject = reject;
+      this.tun.resumePolling();
+    });
+  }
+
+  private async writeAndDrain(deviceConn: Socket, data: Buffer): Promise<void> {
+    if (deviceConn.destroyed) {
+      return;
+    }
+
+    const canWriteMore = deviceConn.write(data);
+    if (this.fwdPumpPackets === 1 || this.fwdPumpPackets % 200 === 0 || !canWriteMore) {
+      fwdDebug('pump-write', {
+        len: data.length,
+        canWriteMore,
+        writableLength: deviceConn.writableLength,
+        packets: this.fwdPumpPackets,
+      });
+    }
+    if (!canWriteMore || deviceConn.writableNeedDrain) {
+      fwdDebug('pump-drain-wait', {
+        writableLength: deviceConn.writableLength,
+        len: data.length,
+      });
+      this.drainAbort = new AbortController();
+      try {
+        await once(deviceConn, 'drain', {signal: this.drainAbort.signal});
+      } catch {
+        return;
+      } finally {
+        this.drainAbort = null;
+      }
+      fwdDebug('pump-drain-done', {
+        writableLength: deviceConn.writableLength,
+      });
+    }
+    if (this.cancelled) {
+      return;
+    }
+    this.onForwardProgress?.();
+  }
+
+  private async runLoop(deviceConn: Socket): Promise<void> {
+    try {
+      while (!this.cancelled && !deviceConn.destroyed) {
+        const packet = await this.readOnePacket();
+        if (this.cancelled) {
+          break;
+        }
+        this.fwdPumpPackets += 1;
+        if (this.fwdPumpPackets === 1 || this.fwdPumpPackets % 200 === 0) {
+          fwdDebug('pump-read', {len: packet.length, packets: this.fwdPumpPackets});
+        }
+        await this.writeAndDrain(deviceConn, packet);
+      }
+    } catch {
+      // stop() rejected a pending readOnePacket()
+    }
+    fwdDebug('pump-stop', {packets: this.fwdPumpPackets});
+  }
+}

--- a/src/tunnel/tun-to-device-pump.ts
+++ b/src/tunnel/tun-to-device-pump.ts
@@ -52,10 +52,12 @@ export class TunToDevicePump {
     this.drainAbort = null;
     this.tun.pausePolling();
     if (this.ingressReject) {
-      this.ingressReject(new Error('pump cancelled'));
-      this.ingressReject = null;
+      this.ingressReject(new Error(TUN_PUMP_CANCELLED));
+    } else if (this.ingressWaiter) {
+      this.ingressWaiter();
     }
     this.ingressWaiter = null;
+    this.ingressReject = null;
     this.tunIngressQueue = [];
     if (this.loopPromise) {
       await this.loopPromise.catch(() => undefined);
@@ -96,7 +98,7 @@ export class TunToDevicePump {
 
   private waitForIngress(): Promise<void> {
     if (this.cancelled) {
-      return Promise.reject(new Error('pump cancelled'));
+      return Promise.reject(new Error(TUN_PUMP_CANCELLED));
     }
     if (this.tunIngressQueue.length > 0) {
       return Promise.resolve();
@@ -165,9 +167,17 @@ export class TunToDevicePump {
           await this.writeAndDrain(deviceConn, packet);
         }
       }
-    } catch {
-      // stop() rejected waitForIngress()
+    } catch (err) {
+      if (!isPumpCancelled(err)) {
+        throw err;
+      }
     }
     fwdDebug('pump-stop', {packets: this.fwdPumpPackets});
   }
+}
+
+const TUN_PUMP_CANCELLED = 'pump cancelled';
+
+function isPumpCancelled(err: unknown): boolean {
+  return err instanceof Error && err.message === TUN_PUMP_CANCELLED;
 }

--- a/src/tunnel/tun-to-device-pump.ts
+++ b/src/tunnel/tun-to-device-pump.ts
@@ -86,7 +86,11 @@ export class TunToDevicePump {
 
     this.tunPacketWaiter = null;
     this.readReject = null;
-    waiter(this.tunIngressQueue.shift()!);
+    const packet = this.tunIngressQueue.shift();
+    if (!packet) {
+      return;
+    }
+    waiter(packet);
     this.maybeResumeTunPolling();
   }
 
@@ -102,9 +106,11 @@ export class TunToDevicePump {
     }
 
     if (this.tunIngressQueue.length > 0) {
-      const packet = this.tunIngressQueue.shift()!;
-      this.maybeResumeTunPolling();
-      return Promise.resolve(packet);
+      const packet = this.tunIngressQueue.shift();
+      if (packet) {
+        this.maybeResumeTunPolling();
+        return Promise.resolve(packet);
+      }
     }
 
     return new Promise((resolve, reject) => {

--- a/src/tunnel/tun-to-device-pump.ts
+++ b/src/tunnel/tun-to-device-pump.ts
@@ -2,7 +2,7 @@ import {once} from 'node:events';
 import type {Socket} from 'node:net';
 
 import type {TunTap} from '../TunTap.js';
-import {SEQUENTIAL_TUN_POLL_QUEUE_DEPTH} from './constants.js';
+import {MAX_TUN_INGRESS_QUEUE, TUN_POLL_TSFN_QUEUE_DEPTH} from './constants.js';
 import {fwdDebug} from './forward-debug.js';
 
 export type TunToDeviceProgressHook = () => void;
@@ -14,6 +14,7 @@ export type TunToDeviceProgressHook = () => void;
 export class TunToDevicePump {
   private cancelled = false;
   private running = false;
+  private tunIngressQueue: Buffer[] = [];
   private tunPacketWaiter: ((packet: Buffer) => void) | null = null;
   private readReject: ((err: Error) => void) | null = null;
   private drainAbort: AbortController | null = null;
@@ -37,11 +38,11 @@ export class TunToDevicePump {
     this.tun.startPolling(
       (data: Buffer) => this.onTunPollData(data),
       this.mtu,
-      SEQUENTIAL_TUN_POLL_QUEUE_DEPTH,
+      TUN_POLL_TSFN_QUEUE_DEPTH,
     );
     this.tun.pausePolling();
 
-    fwdDebug('pump-start', {mtu: this.mtu, queueDepth: SEQUENTIAL_TUN_POLL_QUEUE_DEPTH});
+    fwdDebug('pump-start', {mtu: this.mtu, queueDepth: TUN_POLL_TSFN_QUEUE_DEPTH});
     this.loopPromise = this.runLoop(deviceConn);
   }
 
@@ -55,6 +56,7 @@ export class TunToDevicePump {
       this.readReject = null;
     }
     this.tunPacketWaiter = null;
+    this.tunIngressQueue = [];
     if (this.loopPromise) {
       await this.loopPromise.catch(() => undefined);
       this.loopPromise = null;
@@ -67,14 +69,30 @@ export class TunToDevicePump {
       return;
     }
 
-    this.tun.pausePolling();
     this.onPacketRead?.(data);
+    this.tunIngressQueue.push(data);
+    if (this.tunIngressQueue.length >= MAX_TUN_INGRESS_QUEUE) {
+      this.tun.pausePolling();
+      fwdDebug('tun-ingress-pause', {queued: this.tunIngressQueue.length});
+    }
+    this.deliverTunPacket();
+  }
 
+  private deliverTunPacket(): void {
     const waiter = this.tunPacketWaiter;
-    if (waiter) {
-      this.tunPacketWaiter = null;
-      this.readReject = null;
-      waiter(data);
+    if (!waiter || this.tunIngressQueue.length === 0) {
+      return;
+    }
+
+    this.tunPacketWaiter = null;
+    this.readReject = null;
+    waiter(this.tunIngressQueue.shift()!);
+    this.maybeResumeTunPolling();
+  }
+
+  private maybeResumeTunPolling(): void {
+    if (this.tunIngressQueue.length < MAX_TUN_INGRESS_QUEUE) {
+      this.tun.resumePolling();
     }
   }
 
@@ -82,6 +100,13 @@ export class TunToDevicePump {
     if (this.cancelled) {
       return Promise.reject(new Error('pump cancelled'));
     }
+
+    if (this.tunIngressQueue.length > 0) {
+      const packet = this.tunIngressQueue.shift()!;
+      this.maybeResumeTunPolling();
+      return Promise.resolve(packet);
+    }
+
     return new Promise((resolve, reject) => {
       this.tunPacketWaiter = resolve;
       this.readReject = reject;
@@ -104,9 +129,12 @@ export class TunToDevicePump {
       });
     }
     if (!canWriteMore || deviceConn.writableNeedDrain) {
+      // Unblock device→TUN while TLS send buffer drains (utun may accept writes again).
+      this.onForwardProgress?.();
       fwdDebug('pump-drain-wait', {
         writableLength: deviceConn.writableLength,
         len: data.length,
+        tunQueued: this.tunIngressQueue.length,
       });
       this.drainAbort = new AbortController();
       try {
@@ -118,6 +146,7 @@ export class TunToDevicePump {
       }
       fwdDebug('pump-drain-done', {
         writableLength: deviceConn.writableLength,
+        tunQueued: this.tunIngressQueue.length,
       });
     }
     if (this.cancelled) {
@@ -137,6 +166,8 @@ export class TunToDevicePump {
         if (this.fwdPumpPackets === 1 || this.fwdPumpPackets % 200 === 0) {
           fwdDebug('pump-read', {len: packet.length, packets: this.fwdPumpPackets});
         }
+        // Reading from utun may free kernel buffer for inbound utun writes.
+        this.onForwardProgress?.();
         await this.writeAndDrain(deviceConn, packet);
       }
     } catch {

--- a/src/tunnel/tun-to-device-pump.ts
+++ b/src/tunnel/tun-to-device-pump.ts
@@ -8,15 +8,15 @@ import {fwdDebug} from './forward-debug.js';
 export type TunToDeviceProgressHook = () => void;
 
 /**
- * pymobiledevice3-style TUN→device forwarding: read one packet, write, await
- * drain when the socket needs it, then read the next.
+ * TUN→device forwarding: utun poll fills an ingress queue; a writer loop drains
+ * the queue to TLS with backpressure (await drain).
  */
 export class TunToDevicePump {
   private cancelled = false;
   private running = false;
   private tunIngressQueue: Buffer[] = [];
-  private tunPacketWaiter: ((packet: Buffer) => void) | null = null;
-  private readReject: ((err: Error) => void) | null = null;
+  private ingressWaiter: (() => void) | null = null;
+  private ingressReject: ((err: Error) => void) | null = null;
   private drainAbort: AbortController | null = null;
   private loopPromise: Promise<void> | null = null;
   private fwdPumpPackets = 0;
@@ -40,7 +40,7 @@ export class TunToDevicePump {
       this.mtu,
       TUN_POLL_TSFN_QUEUE_DEPTH,
     );
-    this.tun.pausePolling();
+    this.tun.resumePolling();
 
     fwdDebug('pump-start', {mtu: this.mtu, queueDepth: TUN_POLL_TSFN_QUEUE_DEPTH});
     this.loopPromise = this.runLoop(deviceConn);
@@ -51,11 +51,11 @@ export class TunToDevicePump {
     this.drainAbort?.abort();
     this.drainAbort = null;
     this.tun.pausePolling();
-    if (this.readReject) {
-      this.readReject(new Error('pump cancelled'));
-      this.readReject = null;
+    if (this.ingressReject) {
+      this.ingressReject(new Error('pump cancelled'));
+      this.ingressReject = null;
     }
-    this.tunPacketWaiter = null;
+    this.ingressWaiter = null;
     this.tunIngressQueue = [];
     if (this.loopPromise) {
       await this.loopPromise.catch(() => undefined);
@@ -75,23 +75,17 @@ export class TunToDevicePump {
       this.tun.pausePolling();
       fwdDebug('tun-ingress-pause', {queued: this.tunIngressQueue.length});
     }
-    this.deliverTunPacket();
+    this.signalIngress();
   }
 
-  private deliverTunPacket(): void {
-    const waiter = this.tunPacketWaiter;
-    if (!waiter || this.tunIngressQueue.length === 0) {
+  private signalIngress(): void {
+    const waiter = this.ingressWaiter;
+    if (!waiter) {
       return;
     }
-
-    this.tunPacketWaiter = null;
-    this.readReject = null;
-    const packet = this.tunIngressQueue.shift();
-    if (!packet) {
-      return;
-    }
-    waiter(packet);
-    this.maybeResumeTunPolling();
+    this.ingressWaiter = null;
+    this.ingressReject = null;
+    waiter();
   }
 
   private maybeResumeTunPolling(): void {
@@ -100,23 +94,16 @@ export class TunToDevicePump {
     }
   }
 
-  private readOnePacket(): Promise<Buffer> {
+  private waitForIngress(): Promise<void> {
     if (this.cancelled) {
       return Promise.reject(new Error('pump cancelled'));
     }
-
     if (this.tunIngressQueue.length > 0) {
-      const packet = this.tunIngressQueue.shift();
-      if (packet) {
-        this.maybeResumeTunPolling();
-        return Promise.resolve(packet);
-      }
+      return Promise.resolve();
     }
-
     return new Promise((resolve, reject) => {
-      this.tunPacketWaiter = resolve;
-      this.readReject = reject;
-      this.tun.resumePolling();
+      this.ingressWaiter = resolve;
+      this.ingressReject = reject;
     });
   }
 
@@ -135,7 +122,6 @@ export class TunToDevicePump {
       });
     }
     if (!canWriteMore || deviceConn.writableNeedDrain) {
-      // Unblock device→TUN while TLS send buffer drains (utun may accept writes again).
       this.onForwardProgress?.();
       fwdDebug('pump-drain-wait', {
         writableLength: deviceConn.writableLength,
@@ -164,20 +150,23 @@ export class TunToDevicePump {
   private async runLoop(deviceConn: Socket): Promise<void> {
     try {
       while (!this.cancelled && !deviceConn.destroyed) {
-        const packet = await this.readOnePacket();
-        if (this.cancelled) {
-          break;
+        await this.waitForIngress();
+        while (this.tunIngressQueue.length > 0 && !this.cancelled && !deviceConn.destroyed) {
+          const packet = this.tunIngressQueue.shift();
+          if (!packet) {
+            break;
+          }
+          this.maybeResumeTunPolling();
+          this.fwdPumpPackets += 1;
+          if (this.fwdPumpPackets === 1 || this.fwdPumpPackets % 200 === 0) {
+            fwdDebug('pump-read', {len: packet.length, packets: this.fwdPumpPackets});
+          }
+          this.onForwardProgress?.();
+          await this.writeAndDrain(deviceConn, packet);
         }
-        this.fwdPumpPackets += 1;
-        if (this.fwdPumpPackets === 1 || this.fwdPumpPackets % 200 === 0) {
-          fwdDebug('pump-read', {len: packet.length, packets: this.fwdPumpPackets});
-        }
-        // Reading from utun may free kernel buffer for inbound utun writes.
-        this.onForwardProgress?.();
-        await this.writeAndDrain(deviceConn, packet);
       }
     } catch {
-      // stop() rejected a pending readOnePacket()
+      // stop() rejected waitForIngress()
     }
     fwdDebug('pump-stop', {packets: this.fwdPumpPackets});
   }

--- a/src/tunnel/tun-to-device-pump.ts
+++ b/src/tunnel/tun-to-device-pump.ts
@@ -3,7 +3,7 @@ import type {Socket} from 'node:net';
 
 import type {TunTap} from '../TunTap.js';
 import {MAX_TUN_INGRESS_QUEUE, TUN_POLL_TSFN_QUEUE_DEPTH} from './constants.js';
-import {fwdDebug} from './forward-debug.js';
+import {fwdDebug} from './debug-log.js';
 
 export type TunToDeviceProgressHook = () => void;
 

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -381,12 +381,14 @@ void TunDevice::StopPollingLocked() {
 }
 
 void TunDevice::ReleaseTsfnLocked() {
-  if (poll_dispatch_ != nullptr) {
-    delete poll_dispatch_;
-    poll_dispatch_ = nullptr;
-  }
+  // Release TSFN first — it blocks until queued callbacks finish. Those callbacks
+  // may still dereference poll_dispatch_, so it must outlive the TSFN drain.
   if (tsfn_) {
     tsfn_.Release();
     tsfn_ = nullptr;
+  }
+  if (poll_dispatch_ != nullptr) {
+    delete poll_dispatch_;
+    poll_dispatch_ = nullptr;
   }
 }

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -6,9 +6,71 @@
 #include <mutex>
 #include <string>
 #include <utility>
-#include <vector>
+#include <deque>
 
 #include "native/tun_backend.h"
+
+struct TunPollDispatch {
+  Napi::ThreadSafeFunction tsfn;
+  std::mutex mutex;
+  std::deque<std::vector<uint8_t>> pending;
+
+  struct PacketJob {
+    TunPollDispatch* dispatch;
+    std::vector<uint8_t>* packet;
+  };
+
+  static void CallJs(Napi::Env env,
+                     Napi::Function jsCallback,
+                     TunPollDispatch* self,
+                     std::vector<uint8_t>* packet) {
+    if (env == nullptr || jsCallback.IsEmpty() || packet == nullptr) {
+      delete packet;
+      return;
+    }
+    auto* backing = packet;
+    Napi::Buffer<uint8_t> buf = Napi::Buffer<uint8_t>::New(
+        env,
+        backing->data(),
+        backing->size(),
+        [](Napi::Env, uint8_t*, std::vector<uint8_t>* vec) { delete vec; },
+        backing);
+    jsCallback.Call({buf});
+    if (self != nullptr) {
+      self->FlushPending();
+    }
+  }
+
+  void FlushPending() {
+    std::lock_guard<std::mutex> lock(mutex);
+    while (!pending.empty()) {
+      auto* packet = new std::vector<uint8_t>(std::move(pending.front()));
+      auto* job = new PacketJob{this, packet};
+      napi_status status = tsfn.NonBlockingCall(
+          job,
+          [](Napi::Env env, Napi::Function jsCallback, PacketJob* job) {
+            CallJs(env, jsCallback, job->dispatch, job->packet);
+            delete job;
+          });
+      if (status != napi_ok) {
+        delete packet;
+        delete job;
+        break;
+      }
+      pending.pop_front();
+    }
+  }
+
+  bool PostPacket(std::vector<uint8_t> packet) {
+    {
+      std::lock_guard<std::mutex> lock(mutex);
+      pending.push_back(std::move(packet));
+    }
+    FlushPending();
+    std::lock_guard<std::mutex> lock(mutex);
+    return pending.empty();
+  }
+};
 
 class TunDevice : public Napi::ObjectWrap<TunDevice> {
 public:
@@ -38,6 +100,7 @@ private:
   std::mutex device_mutex_;
 
   Napi::ThreadSafeFunction tsfn_;
+  TunPollDispatch* poll_dispatch_ = nullptr;
   std::atomic<bool> polling_;
   static constexpr size_t MAX_POLL_BUFFER = 65535;
 
@@ -240,21 +303,11 @@ Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
   }
 
   Napi::ThreadSafeFunction tsfn = tsfn_;
-  auto packet_cb = [tsfn](std::vector<uint8_t> packet) mutable {
-    tsfn.BlockingCall(
-        [packet = std::move(packet)](Napi::Env env, Napi::Function jsCallback) mutable {
-          if (env == nullptr || jsCallback.IsEmpty()) {
-            return;
-          }
-          auto* backing = new std::vector<uint8_t>(std::move(packet));
-          Napi::Buffer<uint8_t> buf = Napi::Buffer<uint8_t>::New(
-              env,
-              backing->data(),
-              backing->size(),
-              [](Napi::Env, uint8_t*, std::vector<uint8_t>* vec) { delete vec; },
-              backing);
-          jsCallback.Call({buf});
-        });
+  auto* dispatch = new TunPollDispatch();
+  dispatch->tsfn = tsfn;
+  poll_dispatch_ = dispatch;
+  auto packet_cb = [dispatch](std::vector<uint8_t> packet) mutable -> bool {
+    return dispatch->PostPacket(std::move(packet));
   };
   // Terminal errors from the receive loop (poll error, device closed, read
   // error) call back here so the JS-side polling_ flag and TSFN are released
@@ -326,6 +379,10 @@ void TunDevice::StopPollingLocked() {
 }
 
 void TunDevice::ReleaseTsfnLocked() {
+  if (poll_dispatch_ != nullptr) {
+    delete poll_dispatch_;
+    poll_dispatch_ = nullptr;
+  }
   if (tsfn_) {
     tsfn_.Release();
     tsfn_ = nullptr;

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -14,6 +14,7 @@ struct TunPollDispatch {
   Napi::ThreadSafeFunction tsfn;
   std::mutex mutex;
   std::deque<std::vector<uint8_t>> pending;
+  static constexpr size_t MAX_PENDING = 512;
 
   struct PacketJob {
     TunPollDispatch* dispatch;
@@ -68,7 +69,8 @@ struct TunPollDispatch {
     }
     FlushPending();
     std::lock_guard<std::mutex> lock(mutex);
-    return pending.empty();
+    // Stop reading more from utun until JS drains the backlog.
+    return pending.size() < MAX_PENDING;
   }
 };
 

--- a/test/integration/tuntap-integration.spec.mjs
+++ b/test/integration/tuntap-integration.spec.mjs
@@ -10,7 +10,7 @@ import {hasPrivileges} from '../utils.mjs';
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
 
-describe('TunTap Integration Tests', () => {
+describe('TunTap Integration Tests', {timeout: 15000}, () => {
   let tun;
 
   before(async () => {
@@ -74,7 +74,7 @@ describe('TunTap Integration Tests', () => {
     assert.strictEqual(tun.close(), true, 'TUN device should close');
   });
 
-  it('should read and write data (simulate traffic)', async () => {
+  it('should read and write data (simulate traffic)', {timeout: 10000}, async () => {
     tun = new TunTap();
     assert.strictEqual(tun.open(), true, 'TUN device should open');
     await tun.configure('fd00::1', 1500);

--- a/test/unit/tunnel/manager-forwarding.spec.mjs
+++ b/test/unit/tunnel/manager-forwarding.spec.mjs
@@ -230,6 +230,28 @@ describe('DeviceToTunPump', {timeout: 5000}, () => {
 
     await pump.stop();
   });
+
+  it('stop() returns while utun write is blocked', async () => {
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+    tun.write = () => 0;
+
+    const pump = new DeviceToTunPump();
+    pump.start(socket, tun);
+
+    const packet = Buffer.alloc(1280);
+    packet[0] = 0x60;
+    packet.writeUInt16BE(1240, 4);
+    socket.emit('data', packet);
+
+    await new Promise((resolve) => setImmediate(resolve));
+
+    const stopPromise = pump.stop();
+    const timeout = new Promise((_resolve, reject) => {
+      setTimeout(() => reject(new Error('stop timed out')), 1000);
+    });
+    await Promise.race([stopPromise, timeout]);
+  });
 });
 
 describe('TunnelManager forwarding', {timeout: 5000}, () => {

--- a/test/unit/tunnel/manager-forwarding.spec.mjs
+++ b/test/unit/tunnel/manager-forwarding.spec.mjs
@@ -2,13 +2,10 @@ import assert from 'node:assert';
 import {EventEmitter} from 'node:events';
 import {describe, it} from 'node:test';
 
-import {
-  DEFAULT_TUN_POLL_QUEUE_DEPTH,
-  FAST_TUN_POLL_QUEUE_DEPTH,
-  LARGE_TUN_POLL_BUFFER,
-  MAX_TUN_POLL_BUFFER,
-} from '../../../lib/tunnel/constants.js';
+import {TUN_POLL_TSFN_QUEUE_DEPTH} from '../../../lib/tunnel/constants.js';
 import {TunnelManager} from '../../../lib/tunnel/manager.js';
+import {TunToDevicePump} from '../../../lib/tunnel/tun-to-device-pump.js';
+import {DeviceToTunPump} from '../../../lib/tunnel/device-to-tun-pump.js';
 
 class MockTunTap {
   constructor() {
@@ -52,8 +49,8 @@ class MockSocket extends EventEmitter {
   constructor() {
     super();
     this.destroyed = false;
-    this.writableNeedDrain = false;
     this._writable = true;
+    this.writableLength = 0;
     this.paused = false;
   }
 
@@ -63,6 +60,9 @@ class MockSocket extends EventEmitter {
 
   write(data) {
     this.emit('written', data);
+    if (!this._writable) {
+      this.writableLength += data.length;
+    }
     return this._writable;
   }
 
@@ -80,58 +80,209 @@ class MockSocket extends EventEmitter {
   }
 }
 
-describe('TunnelManager forwarding', () => {
-  it('uses a larger poll buffer and deeper queue when packet tap is off', () => {
-    const manager = new TunnelManager();
+describe('TunToDevicePump', {timeout: 5000}, () => {
+  it('reads one MTU frame at a time with sequential queue depth', async () => {
     const tun = new MockTunTap();
     const socket = new MockSocket();
+    const written = [];
+    socket.write = (data) => {
+      written.push(Buffer.from(data));
+      return true;
+    };
 
-    manager.tun = tun;
-    manager.mtu = 1280;
-    manager.startTunReadLoop(socket);
-
-    assert.strictEqual(
-      tun.pollBuffer,
-      Math.min(MAX_TUN_POLL_BUFFER, Math.max(1280, LARGE_TUN_POLL_BUFFER)),
-    );
-    assert.strictEqual(tun.queueDepth, FAST_TUN_POLL_QUEUE_DEPTH);
-  });
-
-  it('uses MTU-sized poll buffer and default queue when packet tap is on', () => {
-    const manager = new TunnelManager();
-    const tun = new MockTunTap();
-    const socket = new MockSocket();
-
-    manager.addPacketConsumer({onPacket: () => {}});
-    manager.tun = tun;
-    manager.mtu = 1280;
-    manager.startTunReadLoop(socket);
+    const pump = new TunToDevicePump(tun, 1280);
+    pump.start(socket);
 
     assert.strictEqual(tun.pollBuffer, 1280);
-    assert.strictEqual(tun.queueDepth, DEFAULT_TUN_POLL_QUEUE_DEPTH);
+    assert.strictEqual(tun.queueDepth, TUN_POLL_TSFN_QUEUE_DEPTH);
+
+    tun.resumePolling();
+    tun.callback(Buffer.from([0x60, 0, 0, 1]));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(written.length, 1);
+
+    await pump.stop();
   });
 
-  it('pauses TUN polling when the device socket write buffer fills', () => {
+  it('waits for drain before reading the next packet', async () => {
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+    const written = [];
+    socket.write = (data) => {
+      written.push(Buffer.from(data));
+      return socket._writable;
+    };
+    socket._writable = false;
+
+    const pump = new TunToDevicePump(tun, 1280);
+    pump.start(socket);
+
+    tun.resumePolling();
+    tun.callback(Buffer.from([0x60, 0, 0, 1]));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(written.length, 1);
+    assert.strictEqual(tun.paused, false);
+
+    tun.callback(Buffer.from([0x60, 0, 0, 2]));
+    socket._writable = true;
+    socket.emit('drain');
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(written.length, 2);
+    await pump.stop();
+  });
+
+  it('notifies tun writable when waiting for TLS drain', async () => {
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+    let notifyCount = 0;
+    socket.write = (data) => {
+      socket.emit('written', data);
+      return socket._writable;
+    };
+    socket._writable = false;
+
+    const pump = new TunToDevicePump(tun, 1280, undefined, () => {
+      notifyCount += 1;
+    });
+    pump.start(socket);
+
+    tun.resumePolling();
+    tun.callback(Buffer.from([0x60, 0, 0, 1]));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.ok(notifyCount >= 1, 'expected notify before/during drain wait');
+
+    await pump.stop();
+  });
+
+  it('buffers burst utun packets instead of dropping them', async () => {
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+    const written = [];
+    socket.write = (data) => {
+      written.push(Buffer.from(data));
+      return true;
+    };
+
+    const pump = new TunToDevicePump(tun, 1280);
+    pump.start(socket);
+
+    tun.resumePolling();
+    tun.callback(Buffer.from([0x60, 0, 0, 1]));
+    tun.callback(Buffer.from([0x60, 0, 0, 2]));
+    await new Promise((resolve) => setImmediate(resolve));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(written.length, 2);
+
+    await pump.stop();
+  });
+});
+
+describe('DeviceToTunPump', {timeout: 5000}, () => {
+  it('reads one IPv6 frame at a time and yields between frames', async () => {
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+    const written = [];
+    tun.write = (data) => {
+      written.push(Buffer.from(data));
+      return data.length;
+    };
+
+    const pump = new DeviceToTunPump();
+    pump.start(socket, tun);
+
+    const packet = Buffer.alloc(1280);
+    packet[0] = 0x60;
+    packet.writeUInt16BE(1240, 4);
+    socket.emit('data', packet);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.strictEqual(written.length, 1);
+    assert.strictEqual(written[0].length, 1280);
+
+    await pump.stop();
+  });
+
+  it('does not pause device ingress when utun write blocks', async () => {
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+    let blocked = true;
+    tun.write = () => (blocked ? 0 : 1280);
+
+    const pump = new DeviceToTunPump();
+    pump.start(socket, tun);
+
+    const packet = Buffer.alloc(1280);
+    packet[0] = 0x60;
+    packet.writeUInt16BE(1240, 4);
+    socket.emit('data', packet);
+
+    await new Promise((resolve) => setImmediate(resolve));
+    assert.strictEqual(socket.paused, false);
+
+    blocked = false;
+    pump.notifyTunWritable();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    await pump.stop();
+  });
+});
+
+describe('TunnelManager forwarding', {timeout: 5000}, () => {
+  it('starts sequential TUN→device pump when packet tap is off', () => {
     const manager = new TunnelManager();
     const tun = new MockTunTap();
     const socket = new MockSocket();
-    socket._writable = false;
 
     manager.tun = tun;
     manager.mtu = 1280;
-    manager.startTunReadLoop(socket);
+    manager.startTunToDevicePump(socket);
 
-    const packet = Buffer.from([0x60, 0, 0, 0, 0, 0, 0, 0]);
-    tun.callback(packet);
+    assert.strictEqual(tun.pollBuffer, 1280);
+    assert.strictEqual(tun.queueDepth, TUN_POLL_TSFN_QUEUE_DEPTH);
+  });
 
-    assert.strictEqual(tun.paused, true);
-    assert.strictEqual(manager.tunReadPausedForBackpressure, true);
+  it('pauses device ingress when TUN write blocks and resumes after forward progress', async () => {
+    const manager = new TunnelManager();
+    const tun = new MockTunTap();
+    const socket = new MockSocket();
+    let blockedOnce = true;
+    tun.write = () => {
+      if (blockedOnce) {
+        blockedOnce = false;
+        return 0;
+      }
+      return 1280;
+    };
 
-    socket._writable = true;
-    socket.emit('drain');
+    manager.tun = tun;
+    manager.deviceConn = socket;
+    manager.mtu = 1280;
 
-    assert.strictEqual(tun.paused, false);
-    assert.strictEqual(manager.tunReadPausedForBackpressure, false);
+    const packet = Buffer.alloc(1280);
+    packet[0] = 0x60;
+    packet.writeUInt16BE(1240, 4);
+    manager.buffer = packet;
+
+    manager.processBuffer();
+
+    assert.strictEqual(socket.paused, true);
+    assert.strictEqual(manager.deviceIngressPaused, true);
+    assert.strictEqual(manager.buffer.length, 1280);
+
+    manager.startTunToDevicePump(socket);
+    tun.resumePolling();
+    tun.callback(Buffer.from([0x60, 0, 0, 0, 0, 0, 0, 0]));
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.strictEqual(manager.deviceIngressPaused, false);
+    assert.strictEqual(manager.buffer.length, 0);
+
+    await manager.tunToDevicePump?.stop();
   });
 
   it('logs TUN write errors and advances past the frame', () => {
@@ -170,13 +321,13 @@ describe('TunnelManager forwarding', () => {
     incompleteTail[0] = 0x60;
 
     manager.buffer = Buffer.concat([complete, incompleteTail]);
-    manager.deviceIngressPausedForTun = true;
+    manager.deviceIngressPaused = true;
     socket.paused = true;
 
     manager.processBuffer();
 
     assert.strictEqual(socket.paused, false);
-    assert.strictEqual(manager.deviceIngressPausedForTun, false);
+    assert.strictEqual(manager.deviceIngressPaused, false);
     assert.strictEqual(manager.buffer.length, 20);
   });
 });

--- a/test/unit/tuntap-unit.spec.mjs
+++ b/test/unit/tuntap-unit.spec.mjs
@@ -9,7 +9,7 @@ import {hasPrivileges} from '../utils.mjs';
  * Administrator on Windows). They fail fast otherwise.
  */
 
-describe('TunTap Unit Tests', () => {
+describe('TunTap Unit Tests', {timeout: 10000}, () => {
   let tun;
 
   before(async () => {


### PR DESCRIPTION
## Summary

Replace the tunnel manager’s inline bidirectional forwarding with **two independent pumps** (TUN→device and device→TUN), and fix native utun polling so sustained bidirectional traffic (AFC push/pull, zip_conduit) no longer wedges or drops TCP ACKs after the first transfer round.

### Problem

Large bidirectional transfers over the RSD tunnel showed a consistent failure mode:

- **Round 1** often succeeded at full speed
- **Round 2+ pull** stalled (~2.9 MiB of 4 MiB received), then READ timeout / connection wedge
- Forward logs showed `device→TUN` flooding while `TUN→device` went idle — **TCP ACKs from utun were lost or delayed**
- zip_conduit on a **degraded** tunnel dropped from ~36 MiB/s to ~3 MiB/s without restart

Root causes identified:

1. **Native utun poll used `BlockingCall`** — poll thread blocked while JS handled device→TUN floods, starving utun reads
2. **Burst utun reads dropped packets** — poll drained multiple frames per wake but the JS pump only consumed one
3. **Cross-pump deadlock** — `TUN→device` blocked on TLS drain while `device→TUN` blocked on full utun; progress signals were insufficient
4. **Event-loop starvation** — synchronous device `data` handling prevented utun TSFN callbacks from running

### Solution

**Dual-pump architecture** (when L4 packet tap is off):

- **`TunToDevicePump`** — utun poll → JS ingress queue (256 packets) → sequential TLS writes with `await drain`
- **`DeviceToTunPump`** — TLS `data` → IPv6 reassembly → utun write; deferred via `setImmediate` so utun callbacks can interleave

**Native addon (`tuntap.cc`):**

- Replace `BlockingCall` with **`NonBlockingCall` + spill buffer** (`TunPollDispatch`)
- Pause utun poll when pending backlog ≥ 512 packets (backpressure without dropping)

**Backpressure / progress wiring:**

- `deviceConn.on('drain')` → `notifyTunWritable()` (unblock device→TUN during TLS drain)
- `onForwardProgress()` before TLS drain wait and after utun poll delivery
- Device ingress paused only at 8 MiB reassembly cap (not on utun write block)

**Diagnostics:**

- `forward-debug.ts` — opt-in debug logs via `APPIUM_TUNTAP_DEBUG=1`

### Results (manual, `appium-ios-remotexpc` + physical device)

| Scenario | Before | After |
|----------|--------|-------|
| AFC 4 MiB × 5 rounds (one session) | Round 2 pull wedge | **5/5 pass** (~6–13 MiB/s round-trip) |
| AFC 4 MiB × 20 rounds | Fail ~round 12 | **20/20 pass** (throughput drifts down over session) |
| zip_conduit 208 MiB upload (fresh tunnel) | — | **~36 MiB/s** |
| zip_conduit after long AFC run (no restart) | — | **~3 MiB/s** (tunnel-wide degradation) |

Round-2 wedge is fixed. **Long-session throughput drift** on bidirectional AFC remains an open follow-up.

## Changes

- `src/tunnel/tun-to-device-pump.ts` — new
- `src/tunnel/device-to-tun-pump.ts` — new
- `src/tunnel/manager.ts` — orchestrate pumps; packet-tap path unchanged
- `src/tunnel/constants.ts` — pump queue depths, ingress limits
- `src/tunnel/forward-debug.ts` — new
- `src/tuntap.cc` — non-blocking TSFN dispatch + spill buffer
- `src/native/posix_uv_poll_loop.cc`, `tun_backend.h`, `tun_backend_windows.cc` — poll callback backpressure signal
- `test/unit/tunnel/manager-forwarding.spec.mjs` — pump unit tests (8 cases)
