### PR TITLE
fix: Logging on tunnel shutdown

### DIFF
--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -421,11 +421,11 @@ TunReadResult TunnelForwarder::ReadTunPacket(std::vector<uint8_t>& out) {
   if (errno == EAGAIN || errno == EWOULDBLOCK) {
     tuntap::FwdDebug("forwarder-tun-poll", "fd=%d", tun_fd_);
     if (!PollFd(tun_fd_, POLLIN, &running_, TimePoint::max())) {
-      return TunReadResult::kFatal;
+      return running_.load() ? TunReadResult::kFatal : TunReadResult::kWouldBlock;
     }
     return TunReadResult::kWouldBlock;
   }
-  return TunReadResult::kFatal;
+  return running_.load() ? TunReadResult::kFatal : TunReadResult::kWouldBlock;
 }
 
 ssize_t TunnelForwarder::WriteTunPacket(const uint8_t* data, size_t len) {
@@ -488,14 +488,18 @@ void TunnelForwarder::TunToDeviceLoop() {
   while (running_.load()) {
     const TunReadResult read_result = ReadTunPacket(packet);
     if (read_result == TunReadResult::kFatal) {
-      Fail("TUN read failed in tun-to-device loop");
+      if (running_.load()) {
+        Fail("TUN read failed in tun-to-device loop");
+      }
       return;
     }
     if (read_result != TunReadResult::kOk || packet.empty()) {
       continue;
     }
     if (SslWriteAll(packet.data(), packet.size()) < 0) {
-      Fail("SSL write failed in tun-to-device loop");
+      if (running_.load()) {
+        Fail("SSL write failed in tun-to-device loop");
+      }
       return;
     }
     const uint64_t count = ++tun_writes_;
@@ -539,7 +543,9 @@ void TunnelForwarder::DeviceToTunLoop() {
 
     for (const auto& frame : frames) {
       if (WriteTunPacket(frame.data(), frame.size()) < 0) {
-        Fail("TUN write failed in device-to-tun loop");
+        if (running_.load()) {
+          Fail("TUN write failed in device-to-tun loop");
+        }
         return;
       }
     }

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -85,6 +85,10 @@ export class TunnelManager {
     tunDebug(`Starting OpenSSL tunnel forwarding for ${this.tun.name}`);
     this.forwarder = forwarder;
     forwarder.startForwarding(this.tun.fd, (message) => {
+      if (this.cancelled) {
+        tunDebug(`Ignoring forwarder error during shutdown: ${message}`);
+        return;
+      }
       log.error('Tunnel forwarder error:', message);
       setImmediate(() => {
         void (async () => {


### PR DESCRIPTION
## Summary

- Suppress spurious `ERR! TunTap Tunnel forwarder error: TUN read failed in tun-to-device loop` logs when a tunnel is stopped intentionally (e.g. Ctrl+C in `tunnel-creation.mjs`).
- `TunnelManager.stop()` already sets a `cancelled` flag before closing the TUN fd; the forwarder error callback now checks that flag and skips error logging / `onDead` handling during shutdown.
- Native forwarder loops now treat TUN/SSL I/O failures as non-fatal when `running_` is already false, matching the existing shutdown behavior in `DeviceToTunLoop`.

## Problem

Graceful tunnel shutdown closes the TUN device before stopping the native forwarder so blocked read/write threads can unblock. That causes the `tun-to-device` loop to hit a fatal TUN read, which invoked the error callback and logged an error even though shutdown was expected:

```
info TunnelCreation Cleanup completed.
ERR! TunTap Tunnel forwarder error: TUN read failed in tun-to-device loop
```

## Solution

**TypeScript (`src/tunnel/manager.ts`)**  
Ignore forwarder error callbacks when `cancelled` is true (debug log only).

**Native (`src/native/tunnel_forwarder.cc`)**  
- `ReadTunPacket`: return `kWouldBlock` instead of `kFatal` when `running_` is false.  
- `TunToDeviceLoop` / `DeviceToTunLoop`: only call `Fail()` if `running_` is still true.

Real unexpected failures (device disconnect, SSL errors while the tunnel is active) are unchanged.
