### PR TITLE
feat: enable Windows native tunnel forwarder

### DIFF
--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -60,6 +60,13 @@ jobs:
         if ! sudo apt-get install -y linux-headers-$(uname -r); then
           sudo apt-get install -y linux-headers-generic
         fi
+    - name: Install Windows OpenSSL
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows-static" } else { "x64-windows-static" }
+        vcpkg install "openssl:$triplet"
+        "OPENSSL_ROOT_DIR=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - run: npm install --no-package-lock
       name: Install dependencies
     - name: Create N-API prebuild

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -37,7 +37,7 @@ jobs:
             arch: arm64
             artifact: linux-arm64
             upload: true
-          - runs-on: windows-latest
+          - runs-on: windows-2022
             arch: x64
             artifact: win32-x64
             upload: true
@@ -60,13 +60,28 @@ jobs:
         if ! sudo apt-get install -y linux-headers-$(uname -r); then
           sudo apt-get install -y linux-headers-generic
         fi
-    - name: Install Windows OpenSSL
+    - name: Configure Windows vcpkg cache
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
         $triplet = if ("${{ matrix.arch }}" -eq "arm64") { "arm64-windows-static" } else { "x64-windows-static" }
-        vcpkg install "openssl:$triplet"
-        "OPENSSL_ROOT_DIR=$env:VCPKG_INSTALLATION_ROOT\installed\$triplet" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "VCPKG_OPENSSL_TRIPLET=$triplet" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        "VCPKG_DEFAULT_BINARY_CACHE=$env:RUNNER_TEMP\vcpkg-binary-cache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\vcpkg-binary-cache" | Out-Null
+    - name: Restore Windows vcpkg binary cache
+      if: runner.os == 'Windows'
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}\vcpkg-binary-cache
+        key: ${{ runner.os }}-vcpkg-openssl-${{ matrix.arch }}-${{ hashFiles('.github/workflows/prebuild.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-openssl-${{ matrix.arch }}-
+    - name: Install Windows OpenSSL
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        vcpkg install "openssl:$env:VCPKG_OPENSSL_TRIPLET"
+        "OPENSSL_ROOT_DIR=$env:VCPKG_INSTALLATION_ROOT\installed\$env:VCPKG_OPENSSL_TRIPLET" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
     - run: npm install --no-package-lock
       name: Install dependencies
     - name: Create N-API prebuild

--- a/.github/workflows/prebuild.yml
+++ b/.github/workflows/prebuild.yml
@@ -82,7 +82,7 @@ jobs:
       run: |
         vcpkg install "openssl:$env:VCPKG_OPENSSL_TRIPLET"
         "OPENSSL_ROOT_DIR=$env:VCPKG_INSTALLATION_ROOT\installed\$env:VCPKG_OPENSSL_TRIPLET" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
-    - run: npm install --no-package-lock
+    - run: npm install --no-package-lock --ignore-scripts
       name: Install dependencies
     - name: Create N-API prebuild
       run: npm run build:prebuilds -- --arch ${{ matrix.arch }}

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -55,6 +55,22 @@ jobs:
         # Load the TUN module
         sudo modprobe tun
 
+    - name: Configure Windows vcpkg cache
+      if: ${{ contains(inputs.image, 'windows') }}
+      shell: pwsh
+      run: |
+        "VCPKG_DEFAULT_BINARY_CACHE=$env:RUNNER_TEMP\vcpkg-binary-cache" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+        New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\vcpkg-binary-cache" | Out-Null
+
+    - name: Restore Windows vcpkg binary cache
+      if: ${{ contains(inputs.image, 'windows') }}
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.temp }}\vcpkg-binary-cache
+        key: ${{ runner.os }}-vcpkg-openssl-x64-${{ hashFiles('.github/workflows/shared.yml') }}
+        restore-keys: |
+          ${{ runner.os }}-vcpkg-openssl-x64-
+
     - name: Install Windows OpenSSL
       if: ${{ contains(inputs.image, 'windows') }}
       shell: pwsh

--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -55,12 +55,25 @@ jobs:
         # Load the TUN module
         sudo modprobe tun
 
+    - name: Install Windows OpenSSL
+      if: ${{ contains(inputs.image, 'windows') }}
+      shell: pwsh
+      run: |
+        vcpkg install openssl:x64-windows-static
+        "OPENSSL_ROOT_DIR=$env:VCPKG_INSTALLATION_ROOT\installed\x64-windows-static" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
+
     - uses: SocketDev/action@v1
+      if: ${{ !contains(inputs.image, 'windows') }}
       with:
         mode: firewall-free
 
     - name: Install npm dependencies
+      if: ${{ !contains(inputs.image, 'windows') }}
       run: sfw npm install
+
+    - name: Install npm dependencies
+      if: ${{ contains(inputs.image, 'windows') }}
+      run: npm install --no-package-lock
 
     - name: Run linter
       if: ${{ inputs.run-lint }}
@@ -86,6 +99,7 @@ jobs:
       run: sudo bash test/check-linux-prereqs.sh
 
     - name: Run ${{ inputs.test-name }}
+      if: ${{ !contains(inputs.image, 'windows') }}
       run: |
         # Run test command with sudo and gather diagnostics on failure.
         set +e
@@ -106,3 +120,7 @@ jobs:
         fi
 
         exit $TEST_EXIT_CODE
+
+    - name: Run ${{ inputs.test-name }}
+      if: ${{ contains(inputs.image, 'windows') }}
+      run: ${{ inputs.test-command }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ${{ fromJSON(needs.node_matrix.outputs.versions) }}
-        image: [ubuntu-latest, macos-latest]
+        image: [ubuntu-latest, macos-latest, windows-latest]
     uses: ./.github/workflows/shared.yml
     with:
       image: ${{ matrix.image }}
       node-version: ${{ matrix.node-version }}
-      test-command: npm run test:unit
-      test-name: Unit tests
+      test-command: ${{ matrix.image == 'windows-latest' && 'npm run build:addon' || 'npm run test:unit' }}
+      test-name: ${{ matrix.image == 'windows-latest' && 'Windows native build' || 'Unit tests' }}
       run-lint: true
       run-format-check: true

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -29,7 +29,7 @@ jobs:
     with:
       image: ${{ matrix.image }}
       node-version: ${{ matrix.node-version }}
-      test-command: ${{ contains(matrix.image, 'windows') && 'npm run build:addon' || 'npm run test:unit' }}
-      test-name: ${{ contains(matrix.image, 'windows') && 'Windows native build' || 'Unit tests' }}
+      test-command: npm run test:unit
+      test-name: Unit tests
       run-lint: ${{ !contains(matrix.image, 'windows') }}
       run-format-check: ${{ !contains(matrix.image, 'windows') }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -31,5 +31,5 @@ jobs:
       node-version: ${{ matrix.node-version }}
       test-command: ${{ matrix.image == 'windows-latest' && 'npm run build:addon' || 'npm run test:unit' }}
       test-name: ${{ matrix.image == 'windows-latest' && 'Windows native build' || 'Unit tests' }}
-      run-lint: true
-      run-format-check: true
+      run-lint: ${{ matrix.image != 'windows-latest' }}
+      run-format-check: ${{ matrix.image != 'windows-latest' }}

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -24,12 +24,12 @@ jobs:
       fail-fast: false
       matrix:
         node-version: ${{ fromJSON(needs.node_matrix.outputs.versions) }}
-        image: [ubuntu-latest, macos-latest, windows-latest]
+        image: [ubuntu-latest, macos-latest, windows-2022]
     uses: ./.github/workflows/shared.yml
     with:
       image: ${{ matrix.image }}
       node-version: ${{ matrix.node-version }}
-      test-command: ${{ matrix.image == 'windows-latest' && 'npm run build:addon' || 'npm run test:unit' }}
-      test-name: ${{ matrix.image == 'windows-latest' && 'Windows native build' || 'Unit tests' }}
-      run-lint: ${{ matrix.image != 'windows-latest' }}
-      run-format-check: ${{ matrix.image != 'windows-latest' }}
+      test-command: ${{ contains(matrix.image, 'windows') && 'npm run build:addon' || 'npm run test:unit' }}
+      test-name: ${{ contains(matrix.image, 'windows') && 'Windows native build' || 'Unit tests' }}
+      run-lint: ${{ !contains(matrix.image, 'windows') }}
+      run-format-check: ${{ !contains(matrix.image, 'windows') }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,9 @@ npm run test:integration
 
 # Ad-hoc: run node:test on a single file (add sudo if the test needs root)
 sudo node --test --test-force-exit --test-timeout=120000 test/unit/tuntap-unit.spec.mjs
+
+# Windows elevated PowerShell (Administrator) for privileged native tests
+npm run build:addon; npm run test:unit
 ```
 
 ## Project structure
@@ -103,10 +106,11 @@ Native implementation details are split into `src/native/*`:
 - `prebuilds/<platform>-<arch>/*.node` — N-API binaries shipped in the npm package (built in release CI)
 - `build/Release/tuntap.node` — local compile fallback (from `npm run build:addon` or `node-gyp-build` at install)
 - `lib/` — compiled TypeScript output; `lib/index.js` is the package entry point
+- Windows source builds require static OpenSSL and `OPENSSL_ROOT_DIR` pointing at the installed triplet directory (release CI uses vcpkg `openssl:<arch>-windows-static`).
 
 ### Tests
 
-**`node:test`** **`.mjs`** ES modules under **`test/`**. **`test/unit/tuntap-unit.spec.mjs`** and **`test/integration/tuntap-integration.spec.mjs`** expect **root**. Run test commands with `sudo` when privileged cases are required; non-root runs may skip or fail depending on the case.
+**`node:test`** **`.mjs`** ES modules under **`test/`**. **`test/unit/tuntap-unit.spec.mjs`** and **`test/integration/tuntap-integration.spec.mjs`** expect **root** on POSIX or an elevated PowerShell on Windows. Run test commands with `sudo` on POSIX when privileged cases are required; non-root/non-elevated runs may skip or fail depending on the case.
 
 ### Key constraints
 

--- a/README.md
+++ b/README.md
@@ -92,10 +92,11 @@ On Linux, the module requires:
 
 On Windows the module uses [WinTun](https://www.wintun.net/) (the same userspace TUN driver shipped with WireGuard). Requirements:
 
-1. **`wintun.dll`**: ships with the package. The official signed binaries for `amd64`, `arm64`, `x86`, and `arm` are bundled under `vendor/wintun/bin/<arch>/wintun.dll`; the addon discovers the right one automatically based on its own compile-time architecture. No download or copy step is required.
-2. **Administrator privileges**: required to create the kernel adapter and configure addresses/routes via `netsh`. Launch your shell with **Run as administrator**.
-3. **OpenSSL for source builds**: release prebuilds statically link OpenSSL. If compiling from source on Windows, install static OpenSSL (for example `vcpkg install openssl:x64-windows-static`) and set `OPENSSL_ROOT_DIR` to the installed triplet directory.
-4. **Build toolchain (only if compiling from source)**: Visual Studio Build Tools 2022 with the C++ workload, the Windows 10 SDK, and Python 3.x on `PATH`.
+1. **Apple Mobile Device drivers**: required for USB communication with iOS devices. Install them through Apple's standalone iTunes package for Windows (the non-Microsoft Store installer includes the Apple Mobile Device Support drivers).
+2. **`wintun.dll`**: ships with the package. The official signed binaries for `amd64`, `arm64`, `x86`, and `arm` are bundled under `vendor/wintun/bin/<arch>/wintun.dll`; the addon discovers the right one automatically based on its own compile-time architecture. No download or copy step is required.
+3. **Administrator privileges**: required to create the kernel adapter and configure addresses/routes via `netsh`. Launch your shell with **Run as administrator**.
+4. **OpenSSL for source builds**: release prebuilds statically link OpenSSL. If compiling from source on Windows, install static OpenSSL (for example `vcpkg install openssl:x64-windows-static`) and set `OPENSSL_ROOT_DIR` to the installed triplet directory.
+5. **Build toolchain (only if compiling from source)**: Visual Studio Build Tools 2022 with the C++ workload, the Windows 10 SDK, and Python 3.x on `PATH`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ On Windows the module uses [WinTun](https://www.wintun.net/) (the same userspace
 
 1. **`wintun.dll`**: ships with the package. The official signed binaries for `amd64`, `arm64`, `x86`, and `arm` are bundled under `vendor/wintun/bin/<arch>/wintun.dll`; the addon discovers the right one automatically based on its own compile-time architecture. No download or copy step is required.
 2. **Administrator privileges**: required to create the kernel adapter and configure addresses/routes via `netsh`. Launch your shell with **Run as administrator**.
-3. **Build toolchain (only if compiling from source)**: Visual Studio Build Tools 2022 with the C++ workload, the Windows 10 SDK, and Python 3.x on `PATH`.
+3. **OpenSSL for source builds**: release prebuilds statically link OpenSSL. If compiling from source on Windows, install static OpenSSL (for example `vcpkg install openssl:x64-windows-static`) and set `OPENSSL_ROOT_DIR` to the installed triplet directory.
+4. **Build toolchain (only if compiling from source)**: Visual Studio Build Tools 2022 with the C++ workload, the Windows 10 SDK, and Python 3.x on `PATH`.
 
 ## Usage
 
@@ -173,6 +174,8 @@ const tunnel = await connectToTunnelLockdown(socket, { cert, key });
 console.log('Tunnel established:', tunnel.Address);
 await tunnel.closer();
 ```
+
+`connectToTunnelLockdown()` and `connectToTunnelPsk()` are supported on macOS, Linux, and Windows. On Windows, run from an elevated shell so WinTun adapter creation and `netsh` route configuration can succeed.
 
 ## API Reference
 
@@ -253,6 +256,13 @@ From the project root, run:
 sudo npm run test:unit
 ```
 
+On Windows, use an elevated PowerShell:
+
+```powershell
+npm run build:addon
+npm run test:unit
+```
+
 Or, to run all tests:
 
 ```sh
@@ -260,6 +270,8 @@ sudo npm test
 ```
 
 If you are **not** running as root, you will see a message that tests are skipped.
+
+Windows tunnel-forwarder end-to-end testing requires a real device tunnel source. From an elevated PowerShell, build the addon, run the unit tests, then establish a CoreDevice/RemoteXPC tunnel and verify the forwarded tunnel remains stable under AFC or similar traffic.
 
 ### Manual Testing for Signal Handling (v0.0.4+)
 

--- a/binding.gyp
+++ b/binding.gyp
@@ -113,12 +113,24 @@
           }
         }],
         ["OS=='win'", {
+          "variables": {
+            "openssl_root%": "<!(node -p \"process.env.OPENSSL_ROOT_DIR || process.env.OPENSSL_ROOT || ''\")"
+          },
           "sources": [
+            "src/native/debug_log.cc",
             "src/native/handle.cc",
             "src/native/wintun_loader.cc",
-            "src/native/tun_backend_windows.cc"
+            "src/native/tun_backend_windows.cc",
+            "src/native/tunnel_ssl.cc",
+            "src/native/tunnel_forwarder.cc"
+          ],
+          "include_dirs": [
+            "<(openssl_root)/include"
           ],
           "libraries": [
+            "<(openssl_root)/lib/libssl.lib",
+            "<(openssl_root)/lib/libcrypto.lib",
+            "crypt32.lib",
             "iphlpapi.lib",
             "ws2_32.lib"
           ],

--- a/src/TunTap.ts
+++ b/src/TunTap.ts
@@ -30,6 +30,7 @@ interface NativeTunDevice {
   write(data: Buffer): number;
   getName(): string;
   getFd(): number;
+  getForwardingHandle(): unknown;
   startPolling(callback: PacketCallback, bufferSize?: number, queueDepth?: number): void;
   pausePolling(): void;
   resumePolling(): void;
@@ -100,6 +101,12 @@ export class TunTap {
   /** File descriptor for the open TUN device (for advanced use). */
   get fd(): number {
     return this.device.getFd();
+  }
+
+  /** @internal Opaque native handle consumed by the tunnel forwarder. */
+  get forwardingHandle(): unknown {
+    this.assertReady();
+    return this.device.getForwardingHandle();
   }
 
   /**

--- a/src/native/debug_log.cc
+++ b/src/native/debug_log.cc
@@ -1,5 +1,3 @@
-#if defined(__APPLE__) || defined(__linux__)
-
 #include "debug_log.h"
 
 #include <cstdarg>
@@ -56,5 +54,3 @@ void FwdDebug(const char* event, const char* fmt, ...) {
 }
 
 }  // namespace tuntap
-
-#endif

--- a/src/native/debug_log.h
+++ b/src/native/debug_log.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#if defined(__APPLE__) || defined(__linux__)
-
 namespace tuntap {
 
 /** True when APPIUM_TUNTAP_DEBUG is `1` or `true`. */
@@ -11,8 +9,10 @@ bool DebugEnabled();
 void FwdDebug(const char* event);
 
 /** Log `[fwd] #N event fmt...` to stderr. */
-void FwdDebug(const char* event, const char* fmt, ...) __attribute__((format(printf, 2, 3)));
+void FwdDebug(const char* event, const char* fmt, ...)
+#if defined(__GNUC__) || defined(__clang__)
+    __attribute__((format(printf, 2, 3)))
+#endif
+    ;
 
 }  // namespace tuntap
-
-#endif

--- a/src/native/posix_tun_backend.h
+++ b/src/native/posix_tun_backend.h
@@ -2,6 +2,10 @@
 
 #if defined(__APPLE__) || defined(__linux__)
 
+#include <cerrno>
+#include <poll.h>
+
+#include <chrono>
 #include <string>
 #include <utility>
 #include <vector>
@@ -53,10 +57,48 @@ public:
 
   int GetNativeFd() const override { return fd_.get(); }
 
+  bool WaitReadable(const std::atomic<bool>& running, std::string& error) override {
+    return WaitForEvents(POLLIN, running, error);
+  }
+
+  bool WaitWritable(const std::atomic<bool>& running, std::string& error) override {
+    return WaitForEvents(POLLOUT, running, error);
+  }
+
 protected:
   FileDescriptor fd_;
   std::string interface_name_;
   PosixUvPollLoop poll_loop_;
+
+private:
+  bool WaitForEvents(short events, const std::atomic<bool>& running, std::string& error) {
+    if (!fd_.is_valid()) {
+      error = "Device not open";
+      return false;
+    }
+
+    struct pollfd pfd {};
+    pfd.fd = fd_.get();
+    pfd.events = events;
+
+    while (running.load()) {
+      const int rc = poll(&pfd, 1, 200);
+      if (rc > 0) {
+        if ((pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+          error = "TUN device poll failed";
+          return false;
+        }
+        return (pfd.revents & events) != 0;
+      }
+      if (rc == 0 || errno == EINTR) {
+        continue;
+      }
+      error = "TUN device poll failed";
+      return false;
+    }
+
+    return false;
+  }
 };
 
 #endif

--- a/src/native/tun_backend.h
+++ b/src/native/tun_backend.h
@@ -4,6 +4,7 @@
 #error "appium-ios-tuntap native addon supports only Linux, macOS, and Windows"
 #endif
 
+#include <atomic>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
@@ -62,6 +63,12 @@ public:
   virtual ssize_t WritePacket(const uint8_t* data,
                               size_t length,
                               std::string& error) = 0;
+
+  // Block until a packet can be read/written or `running` becomes false.
+  // Implementations may use short timed waits when the platform does not expose
+  // an explicit writable event.
+  virtual bool WaitReadable(const std::atomic<bool>& running, std::string& error) = 0;
+  virtual bool WaitWritable(const std::atomic<bool>& running, std::string& error) = 0;
 
   // Begin asynchronous packet delivery. `loop` is supplied by Node-API and is
   // used by POSIX backends for `uv_poll_init`; Windows ignores it.

--- a/src/native/tun_backend_windows.cc
+++ b/src/native/tun_backend_windows.cc
@@ -174,7 +174,7 @@ public:
       if (err == ERROR_HANDLE_EOF) {
         error = "WinTun adapter is terminating";
       } else if (err == ERROR_BUFFER_OVERFLOW) {
-        error = "WinTun send-ring is full";
+        return 0;
       } else {
         error = "WintunAllocateSendPacket failed: " + FormatLastError(err);
       }
@@ -258,6 +258,37 @@ public:
   // event `HANDLE`, not a numeric fd. Always -1 — the N-API layer treats -1
   // as "no pollable fd" and drives delivery through `StartReceiveLoop`.
   int GetNativeFd() const override { return -1; }
+
+  bool WaitReadable(const std::atomic<bool>& running, std::string& error) override {
+    if (!read_event_) {
+      error = "Device not open";
+      return false;
+    }
+
+    while (running.load()) {
+      DWORD wait = ::WaitForSingleObject(read_event_, 200);
+      if (wait == WAIT_OBJECT_0) {
+        return true;
+      }
+      if (wait == WAIT_TIMEOUT) {
+        continue;
+      }
+      error = "WaitForSingleObject failed: " + FormatLastError(::GetLastError());
+      return false;
+    }
+
+    return false;
+  }
+
+  bool WaitWritable(const std::atomic<bool>& running, std::string& /*error*/) override {
+    // WinTun exposes only a read-wait event. A short sleep prevents a busy spin
+    // when the send ring is temporarily full.
+    if (running.load()) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(1));
+      return running.load();
+    }
+    return false;
+  }
 
 private:
   static std::string Utf16ToUtf8(const std::wstring& utf16) {

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -3,6 +3,7 @@
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#include <limits>
 #ifndef _WIN32
 #include <fcntl.h>
 #include <poll.h>
@@ -108,7 +109,13 @@ bool ExtractTcpFdFromNodeHandle(const Napi::Value& value, int& fd, std::string& 
     return false;
   }
 
-  fd = static_cast<int>(reinterpret_cast<uintptr_t>(os_fd));
+  const uintptr_t raw_fd = reinterpret_cast<uintptr_t>(os_fd);
+  if (raw_fd > static_cast<uintptr_t>(std::numeric_limits<int>::max())) {
+    error = "Extracted TCP socket handle is too large for OpenSSL fd API";
+    return false;
+  }
+
+  fd = static_cast<int>(raw_fd);
   if (fd < 0) {
     error = "Extracted TCP socket handle is invalid";
     return false;
@@ -235,7 +242,6 @@ uint16_t ComputeIpv6TransportChecksum(const uint8_t* packet, size_t len, uint8_t
   uint32_t sum = 0;
   sum = AddChecksumBytes(sum, packet + 8, 16);
   sum = AddChecksumBytes(sum, packet + 24, 16);
-  sum += 0;
   sum += static_cast<uint16_t>(payload_len & 0xffff);
   sum += protocol;
   sum = AddChecksumBytes(sum, packet + 40, payload_len);
@@ -848,12 +854,13 @@ public:
   TunnelForwarderWrap(const Napi::CallbackInfo& info) : Napi::ObjectWrap<TunnelForwarderWrap>(info) {}
 
   ~TunnelForwarderWrap() override {
-    ReleaseErrorTsfn();
     forwarder_.Stop();
+    ReleaseErrorTsfn();
   }
 
 private:
   void ReleaseErrorTsfn() {
+    std::lock_guard<std::mutex> lock(error_tsfn_mutex_);
     if (error_tsfn_) {
       error_tsfn_.Release();
       error_tsfn_ = nullptr;
@@ -861,6 +868,7 @@ private:
   }
 
   void ReportError(std::string message) {
+    std::lock_guard<std::mutex> lock(error_tsfn_mutex_);
     if (!error_tsfn_) {
       return;
     }
@@ -1010,11 +1018,14 @@ private:
       on_error = info[1].As<Napi::Function>();
     }
 
-    error_tsfn_ = Napi::ThreadSafeFunction::New(env,
-                                                on_error,
-                                                "TunnelForwarderOnError",
-                                                0,
-                                                1);
+    {
+      std::lock_guard<std::mutex> lock(error_tsfn_mutex_);
+      error_tsfn_ = Napi::ThreadSafeFunction::New(env,
+                                                  on_error,
+                                                  "TunnelForwarderOnError",
+                                                  0,
+                                                  1);
+    }
 
     TunPlatformBackend* tun_backend = info[0].As<Napi::External<TunPlatformBackend>>().Data();
     std::string error;
@@ -1033,6 +1044,7 @@ private:
   }
 
   TunnelForwarder forwarder_;
+  std::mutex error_tsfn_mutex_;
   Napi::ThreadSafeFunction error_tsfn_;
 };
 

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -11,6 +11,8 @@
 #include <arpa/inet.h>
 #else
 #include <winsock2.h>
+#include <uv.h>
+#include <v8.h>
 #endif
 
 #include <openssl/err.h>
@@ -34,6 +36,86 @@ constexpr short kPollOut = POLLOUT;
 
 using Clock = std::chrono::steady_clock;
 using TimePoint = Clock::time_point;
+
+#ifdef _WIN32
+v8::Local<v8::Value> ToV8Local(napi_value value) {
+  return *reinterpret_cast<v8::Local<v8::Value>*>(&value);
+}
+
+bool TryReadUvHandle(void* wrapper, size_t offset, uv_tcp_t** out) {
+  bool matched = false;
+#ifdef _MSC_VER
+  __try {
+#endif
+    auto* handle = reinterpret_cast<uv_handle_t*>(
+        reinterpret_cast<uintptr_t>(wrapper) + offset);
+    if (handle->type == UV_TCP && handle->data == wrapper) {
+      *out = reinterpret_cast<uv_tcp_t*>(handle);
+      matched = true;
+    }
+#ifdef _MSC_VER
+  } __except (EXCEPTION_EXECUTE_HANDLER) {
+    matched = false;
+  }
+#endif
+  return matched;
+}
+
+bool ExtractTcpFdFromNodeHandle(const Napi::Value& value, int& fd, std::string& error) {
+  if (!value.IsObject()) {
+    error = "Expected Node TCP handle object";
+    return false;
+  }
+
+  v8::Local<v8::Value> v8_value = ToV8Local(value);
+  if (!v8_value->IsObject()) {
+    error = "Expected V8 object for Node TCP handle";
+    return false;
+  }
+
+  v8::Local<v8::Object> handle_obj = v8_value.As<v8::Object>();
+  if (handle_obj->InternalFieldCount() <= 1) {
+    error = "Node TCP handle has no internal fields";
+    return false;
+  }
+
+  // Node BaseObject stores an embedder tag in field 0 and the C++ wrapper in
+  // BaseObject::kSlot (field 1). TCPWrap is private, so avoid including Node
+  // internals and only use this stable internal-field convention.
+  void* wrapper = handle_obj->GetAlignedPointerFromInternalField(1);
+  if (wrapper == nullptr) {
+    error = "Node TCP handle internal wrapper is null";
+    return false;
+  }
+
+  uv_tcp_t* tcp = nullptr;
+  // TCPWrap is private Node internals. Look for the embedded uv_tcp_t by
+  // scanning the wrapper object for a uv_handle_t whose data points back to it.
+  for (size_t offset = 0; offset < 2048; offset += sizeof(void*)) {
+    if (TryReadUvHandle(wrapper, offset, &tcp)) {
+      break;
+    }
+  }
+  if (tcp == nullptr) {
+    error = "Failed to locate uv_tcp_t in Node TCP handle";
+    return false;
+  }
+
+  uv_os_fd_t os_fd{};
+  const int rc = uv_fileno(reinterpret_cast<const uv_handle_t*>(tcp), &os_fd);
+  if (rc != 0) {
+    error = std::string("uv_fileno failed: ") + uv_strerror(rc);
+    return false;
+  }
+
+  fd = static_cast<int>(reinterpret_cast<uintptr_t>(os_fd));
+  if (fd < 0) {
+    error = "Extracted TCP socket handle is invalid";
+    return false;
+  }
+  return true;
+}
+#endif
 
 std::string EncodeCdTunnelMessage(const std::string& json) {
   std::string out;
@@ -99,6 +181,167 @@ bool ParseHandshakeJson(const std::string& json, TunnelHandshakeInfo& info, std:
   }
   info.server_rsd_port = static_cast<uint16_t>(port);
   return true;
+}
+
+bool IsIcmpv6NeighborDiscovery(const uint8_t* data, size_t len) {
+  if (data == nullptr || len < 41 || (data[0] >> 4) != 6) {
+    return false;
+  }
+  // This forwarder only handles simple IPv6 packets with no extension-header
+  // parsing today. That is enough for Windows NDP packets from WinTun.
+  if (data[6] != 58) {
+    return false;
+  }
+  const uint8_t icmp_type = data[40];
+  return icmp_type >= 133 && icmp_type <= 137;
+}
+
+bool IsIpv6Multicast(const uint8_t* data, size_t len) {
+  return data != nullptr && len >= 40 && (data[0] >> 4) == 6 && data[24] == 0xff;
+}
+
+bool IsIpv6Packet(const uint8_t* data, size_t len) {
+  return data != nullptr && len >= 40 && (data[0] >> 4) == 6;
+}
+
+uint32_t AddChecksumBytes(uint32_t sum, const uint8_t* data, size_t len) {
+  size_t i = 0;
+  for (; i + 1 < len; i += 2) {
+    sum += static_cast<uint16_t>((data[i] << 8) | data[i + 1]);
+  }
+  if (i < len) {
+    sum += static_cast<uint16_t>(data[i] << 8);
+  }
+  return sum;
+}
+
+uint16_t FinishChecksum(uint32_t sum) {
+  while ((sum >> 16) != 0) {
+    sum = (sum & 0xffff) + (sum >> 16);
+  }
+  return static_cast<uint16_t>(~sum);
+}
+
+uint16_t ComputeIpv6TransportChecksum(const uint8_t* packet, size_t len, uint8_t protocol) {
+  if (packet == nullptr || len < 40 || (packet[0] >> 4) != 6) {
+    return 0;
+  }
+
+  const uint16_t payload_len = static_cast<uint16_t>((packet[4] << 8) | packet[5]);
+  if (payload_len == 0 || len < 40 + payload_len) {
+    return 0;
+  }
+
+  uint32_t sum = 0;
+  sum = AddChecksumBytes(sum, packet + 8, 16);
+  sum = AddChecksumBytes(sum, packet + 24, 16);
+  sum += 0;
+  sum += static_cast<uint16_t>(payload_len & 0xffff);
+  sum += protocol;
+  sum = AddChecksumBytes(sum, packet + 40, payload_len);
+  return FinishChecksum(sum);
+}
+
+bool NormalizeTcpChecksum(std::vector<uint8_t>& packet, uint16_t& old_checksum, uint16_t& new_checksum) {
+  if (packet.size() < 60 || (packet[0] >> 4) != 6 || packet[6] != 6) {
+    return false;
+  }
+
+  const uint16_t payload_len = static_cast<uint16_t>((packet[4] << 8) | packet[5]);
+  if (payload_len < 20 || packet.size() < 40 + payload_len) {
+    return false;
+  }
+
+  constexpr size_t tcp_offset = 40;
+  constexpr size_t checksum_offset = tcp_offset + 16;
+  old_checksum =
+      static_cast<uint16_t>((packet[checksum_offset] << 8) | packet[checksum_offset + 1]);
+  packet[checksum_offset] = 0;
+  packet[checksum_offset + 1] = 0;
+  new_checksum = ComputeIpv6TransportChecksum(packet.data(), packet.size(), 6);
+  packet[checksum_offset] = static_cast<uint8_t>(new_checksum >> 8);
+  packet[checksum_offset + 1] = static_cast<uint8_t>(new_checksum & 0xff);
+  return old_checksum != new_checksum;
+}
+
+std::string FormatIpv6Address(const uint8_t* addr) {
+  char buf[40];
+  std::snprintf(buf,
+                sizeof(buf),
+                "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
+                addr[0],
+                addr[1],
+                addr[2],
+                addr[3],
+                addr[4],
+                addr[5],
+                addr[6],
+                addr[7],
+                addr[8],
+                addr[9],
+                addr[10],
+                addr[11],
+                addr[12],
+                addr[13],
+                addr[14],
+                addr[15]);
+  return buf;
+}
+
+void DebugIpv6Packet(const char* tag, const uint8_t* data, size_t len, uint64_t count) {
+  if (data == nullptr || len < 40 || (data[0] >> 4) != 6) {
+    tuntap::FwdDebug(tag, "len=%zu packets=%llu non-ipv6", len,
+                     static_cast<unsigned long long>(count));
+    return;
+  }
+  const uint16_t payload_len = static_cast<uint16_t>((data[4] << 8) | data[5]);
+  const std::string src = FormatIpv6Address(data + 8);
+  const std::string dst = FormatIpv6Address(data + 24);
+
+  if (data[6] == 6 && len >= 60) {
+    const size_t tcp_offset = 40;
+    const uint16_t src_port = static_cast<uint16_t>((data[tcp_offset] << 8) | data[tcp_offset + 1]);
+    const uint16_t dst_port =
+        static_cast<uint16_t>((data[tcp_offset + 2] << 8) | data[tcp_offset + 3]);
+    const uint8_t flags = data[tcp_offset + 13];
+    tuntap::FwdDebug(tag,
+                     "len=%zu packets=%llu next=%u payload=%u %s:%u -> %s:%u flags=0x%02x",
+                     len,
+                     static_cast<unsigned long long>(count),
+                     data[6],
+                     payload_len,
+                     src.c_str(),
+                     src_port,
+                     dst.c_str(),
+                     dst_port,
+                     flags);
+    return;
+  }
+
+  tuntap::FwdDebug(tag,
+                   "len=%zu packets=%llu next=%u payload=%u %s -> %s",
+                   len,
+                   static_cast<unsigned long long>(count),
+                   data[6],
+                   payload_len,
+                   src.c_str(),
+                   dst.c_str());
+}
+
+void DebugSslError(const char* tag, int ssl_error) {
+  unsigned long openssl_error = ERR_get_error();
+#ifdef _WIN32
+  const int socket_error = WSAGetLastError();
+#else
+  const int socket_error = errno;
+#endif
+  const char* reason = openssl_error == 0 ? nullptr : ERR_reason_error_string(openssl_error);
+  tuntap::FwdDebug(tag,
+                   "ssl_error=%d openssl=%lu reason=%s socket_error=%d",
+                   ssl_error,
+                   openssl_error,
+                   reason == nullptr ? "(none)" : reason,
+                   socket_error);
 }
 
 bool PollFd(int fd, short events, const std::atomic<bool>* running, TimePoint deadline) {
@@ -274,6 +517,7 @@ bool TunnelForwarder::StartForwarding(TunPlatformBackend* tun_backend,
   tun_backend_ = tun_backend;
   running_.store(true);
   tun_writes_.store(0);
+  tun_drops_.store(0);
   ssl_reads_.store(0);
   tuntap::FwdDebug("forwarder-start", "mtu=%zu tunFd=%d", mtu_, tun_backend->GetNativeFd());
   tun_thread_ = std::thread(&TunnelForwarder::TunToDeviceLoop, this);
@@ -340,9 +584,11 @@ ssize_t TunnelForwarder::SslReadChunk(uint8_t* buf, size_t max_len, bool only_wh
       }
       err = SSL_get_error(ssl, n);
       if (err == SSL_ERROR_ZERO_RETURN) {
+        DebugSslError("forwarder-ssl-read-close", err);
         return -1;
       }
       if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+        DebugSslError("forwarder-ssl-read-error", err);
         return -1;
       }
       fd = SSL_get_fd(ssl);
@@ -399,9 +645,11 @@ ssize_t TunnelForwarder::SslWriteAll(const uint8_t* data, size_t len, bool only_
       }
       err = SSL_get_error(ssl, n);
       if (err == SSL_ERROR_ZERO_RETURN) {
+        DebugSslError("forwarder-ssl-write-close", err);
         return -1;
       }
       if (err != SSL_ERROR_WANT_READ && err != SSL_ERROR_WANT_WRITE) {
+        DebugSslError("forwarder-ssl-write-error", err);
         return -1;
       }
       fd = SSL_get_fd(ssl);
@@ -493,6 +741,30 @@ void TunnelForwarder::TunToDeviceLoop() {
     if (read_result != TunReadResult::kOk || packet.empty()) {
       continue;
     }
+    if (!IsIpv6Packet(packet.data(), packet.size())) {
+      const uint64_t count = ++tun_drops_;
+      if (count <= 20 || count % 200 == 0) {
+        DebugIpv6Packet("forwarder-tun-drop-nonipv6", packet.data(), packet.size(), count);
+      }
+      continue;
+    }
+    if (IsIpv6Multicast(packet.data(), packet.size())) {
+      const uint64_t count = ++tun_drops_;
+      if (count <= 20 || count % 200 == 0) {
+        DebugIpv6Packet("forwarder-tun-drop-mcast", packet.data(), packet.size(), count);
+      }
+      continue;
+    }
+    if (IsIcmpv6NeighborDiscovery(packet.data(), packet.size())) {
+      const uint64_t count = ++tun_drops_;
+      if (count <= 20 || count % 200 == 0) {
+        DebugIpv6Packet("forwarder-tun-drop-ndp", packet.data(), packet.size(), count);
+      }
+      continue;
+    }
+    uint16_t old_checksum = 0;
+    uint16_t new_checksum = 0;
+    const bool checksum_changed = NormalizeTcpChecksum(packet, old_checksum, new_checksum);
     if (SslWriteAll(packet.data(), packet.size()) < 0) {
       if (running_.load()) {
         Fail("SSL write failed in tun-to-device loop");
@@ -500,9 +772,14 @@ void TunnelForwarder::TunToDeviceLoop() {
       return;
     }
     const uint64_t count = ++tun_writes_;
-    if (count == 1 || count % 200 == 0) {
-      tuntap::FwdDebug("forwarder-tun-write", "len=%zu packets=%llu", packet.size(),
-                       static_cast<unsigned long long>(count));
+    if (count <= 100 || count % 200 == 0) {
+      DebugIpv6Packet("forwarder-tun-write", packet.data(), packet.size(), count);
+      tuntap::FwdDebug("forwarder-tcp-checksum",
+                       "packets=%llu changed=%s old=0x%04x new=0x%04x",
+                       static_cast<unsigned long long>(count),
+                       checksum_changed ? "true" : "false",
+                       old_checksum,
+                       new_checksum);
     }
   }
 }
@@ -558,7 +835,9 @@ public:
         DefineClass(env,
                     "TunnelForwarder",
                     {InstanceMethod("connect", &TunnelForwarderWrap::Connect),
+                     InstanceMethod("connectSocket", &TunnelForwarderWrap::ConnectSocket),
                      InstanceMethod("connectPsk", &TunnelForwarderWrap::ConnectPsk),
+                     InstanceMethod("connectPskSocket", &TunnelForwarderWrap::ConnectPskSocket),
                      InstanceMethod("handshake", &TunnelForwarderWrap::Handshake),
                      InstanceMethod("startForwarding", &TunnelForwarderWrap::StartForwarding),
                      InstanceMethod("stop", &TunnelForwarderWrap::Stop)});
@@ -616,6 +895,30 @@ private:
     return env.Undefined();
   }
 
+  Napi::Value ConnectSocket(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 3 || !info[1].IsString() || !info[2].IsString()) {
+      Napi::TypeError::New(env, "Expected (tcpHandle, certPem, keyPem)")
+          .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+
+#ifdef _WIN32
+    int tcp_fd = -1;
+    std::string error;
+    if (!ExtractTcpFdFromNodeHandle(info[0], tcp_fd, error) ||
+        !forwarder_.Connect(tcp_fd,
+                            info[1].As<Napi::String>().Utf8Value(),
+                            info[2].As<Napi::String>().Utf8Value(),
+                            error)) {
+      Napi::Error::New(env, error).ThrowAsJavaScriptException();
+    }
+#else
+    Napi::Error::New(env, "connectSocket is only supported on Windows").ThrowAsJavaScriptException();
+#endif
+    return env.Undefined();
+  }
+
   Napi::Value ConnectPsk(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     if (info.Length() < 2 || !info[0].IsNumber() || !info[1].IsBuffer()) {
@@ -638,6 +941,33 @@ private:
                                error)) {
       Napi::Error::New(env, error).ThrowAsJavaScriptException();
     }
+    return env.Undefined();
+  }
+
+  Napi::Value ConnectPskSocket(const Napi::CallbackInfo& info) {
+    Napi::Env env = info.Env();
+    if (info.Length() < 2 || !info[1].IsBuffer()) {
+      Napi::TypeError::New(env, "Expected (tcpHandle, pskBuffer[, identity])")
+          .ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
+
+    std::string identity;
+    if (info.Length() >= 3 && info[2].IsString()) {
+      identity = info[2].As<Napi::String>().Utf8Value();
+    }
+
+#ifdef _WIN32
+    int tcp_fd = -1;
+    std::string error;
+    Napi::Buffer<uint8_t> psk = info[1].As<Napi::Buffer<uint8_t>>();
+    if (!ExtractTcpFdFromNodeHandle(info[0], tcp_fd, error) ||
+        !forwarder_.ConnectPsk(tcp_fd, psk.Data(), psk.Length(), identity, error)) {
+      Napi::Error::New(env, error).ThrowAsJavaScriptException();
+    }
+#else
+    Napi::Error::New(env, "connectPskSocket is only supported on Windows").ThrowAsJavaScriptException();
+#endif
     return env.Undefined();
   }
 

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -190,6 +190,7 @@ bool ParseHandshakeJson(const std::string& json, TunnelHandshakeInfo& info, std:
   return true;
 }
 
+#ifdef _WIN32
 bool IsIcmpv6NeighborDiscovery(const uint8_t* data, size_t len) {
   if (data == nullptr || len < 41 || (data[0] >> 4) != 6) {
     return false;
@@ -269,6 +270,7 @@ bool NormalizeTcpChecksum(std::vector<uint8_t>& packet, uint16_t& old_checksum, 
   packet[checksum_offset + 1] = static_cast<uint8_t>(new_checksum & 0xff);
   return old_checksum != new_checksum;
 }
+#endif
 
 std::string FormatIpv6Address(const uint8_t* addr) {
   char buf[40];
@@ -750,6 +752,7 @@ void TunnelForwarder::TunToDeviceLoop() {
     if (read_result != TunReadResult::kOk || packet.empty()) {
       continue;
     }
+#ifdef _WIN32
     if (!IsIpv6Packet(packet.data(), packet.size())) {
       const uint64_t count = ++tun_drops_;
       if (count <= 20 || count % 200 == 0) {
@@ -774,6 +777,7 @@ void TunnelForwarder::TunToDeviceLoop() {
     uint16_t old_checksum = 0;
     uint16_t new_checksum = 0;
     const bool checksum_changed = NormalizeTcpChecksum(packet, old_checksum, new_checksum);
+#endif
     if (SslWriteAll(packet.data(), packet.size()) < 0) {
       if (running_.load()) {
         Fail("SSL write failed in tun-to-device loop");
@@ -783,12 +787,14 @@ void TunnelForwarder::TunToDeviceLoop() {
     const uint64_t count = ++tun_writes_;
     if (count <= 100 || count % 200 == 0) {
       DebugIpv6Packet("forwarder-tun-write", packet.data(), packet.size(), count);
+#ifdef _WIN32
       tuntap::FwdDebug("forwarder-tcp-checksum",
                        "packets=%llu changed=%s old=0x%04x new=0x%04x",
                        static_cast<unsigned long long>(count),
                        checksum_changed ? "true" : "false",
                        old_checksum,
                        new_checksum);
+#endif
     }
   }
 }

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -295,6 +295,9 @@ std::string FormatIpv6Address(const uint8_t* addr) {
 }
 
 void DebugIpv6Packet(const char* tag, const uint8_t* data, size_t len, uint64_t count) {
+  if (!tuntap::DebugEnabled()) {
+    return;
+  }
   if (data == nullptr || len < 40 || (data[0] >> 4) != 6) {
     tuntap::FwdDebug(tag, "len=%zu packets=%llu non-ipv6", len,
                      static_cast<unsigned long long>(count));

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -1,15 +1,17 @@
-#if defined(__APPLE__) || defined(__linux__)
-
 #include "tunnel_forwarder.h"
 
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
+#ifndef _WIN32
 #include <fcntl.h>
 #include <poll.h>
 #include <unistd.h>
 
 #include <arpa/inet.h>
+#else
+#include <winsock2.h>
+#endif
 
 #include <openssl/err.h>
 
@@ -18,13 +20,17 @@
 
 namespace {
 
-#ifdef __APPLE__
-constexpr size_t kUtunHeaderSize = 4;
-#endif
-
 constexpr char kCdTunnelMagic[] = "CDTunnel";
 constexpr size_t kCdTunnelHeaderSize = 10;
 constexpr size_t kMaxIngressBuffer = 256 * 1024;
+
+#ifdef _WIN32
+constexpr short kPollIn = POLLRDNORM;
+constexpr short kPollOut = POLLWRNORM;
+#else
+constexpr short kPollIn = POLLIN;
+constexpr short kPollOut = POLLOUT;
+#endif
 
 using Clock = std::chrono::steady_clock;
 using TimePoint = Clock::time_point;
@@ -99,8 +105,13 @@ bool PollFd(int fd, short events, const std::atomic<bool>* running, TimePoint de
   if (fd < 0) {
     return false;
   }
+#ifdef _WIN32
+  WSAPOLLFD pfd {};
+  pfd.fd = static_cast<SOCKET>(fd);
+#else
   struct pollfd pfd {};
   pfd.fd = fd;
+#endif
   pfd.events = events;
   for (;;) {
     if (running != nullptr && !running->load()) {
@@ -113,9 +124,17 @@ bool PollFd(int fd, short events, const std::atomic<bool>* running, TimePoint de
     const auto remaining_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
     const int timeout_ms = remaining_ms > 200 ? 200 : static_cast<int>(remaining_ms);
+#ifdef _WIN32
+    const int rc = WSAPoll(&pfd, 1, timeout_ms);
+#else
     const int rc = poll(&pfd, 1, timeout_ms);
+#endif
     if (rc > 0) {
-      if ((pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+      if ((pfd.revents & (POLLERR | POLLHUP
+#ifndef _WIN32
+                          | POLLNVAL
+#endif
+                          )) != 0) {
         return false;
       }
       return (pfd.revents & events) != 0;
@@ -123,7 +142,11 @@ bool PollFd(int fd, short events, const std::atomic<bool>* running, TimePoint de
     if (rc == 0) {
       continue;
     }
+#ifdef _WIN32
+    if (WSAGetLastError() == WSAEINTR) {
+#else
     if (errno == EINTR) {
+#endif
       continue;
     }
     return false;
@@ -219,7 +242,9 @@ bool TunnelForwarder::Handshake(uint32_t requested_mtu, TunnelHandshakeInfo& inf
   return true;
 }
 
-bool TunnelForwarder::StartForwarding(int tun_fd, ForwarderErrorCallback on_error, std::string& error) {
+bool TunnelForwarder::StartForwarding(TunPlatformBackend* tun_backend,
+                                      ForwarderErrorCallback on_error,
+                                      std::string& error) {
   if (running_.load()) {
     error = "Tunnel forwarder already running";
     return false;
@@ -228,8 +253,8 @@ bool TunnelForwarder::StartForwarding(int tun_fd, ForwarderErrorCallback on_erro
     error = "TLS session is not connected";
     return false;
   }
-  if (tun_fd < 0) {
-    error = "Invalid TUN file descriptor";
+  if (tun_backend == nullptr || !tun_backend->IsOpen()) {
+    error = "TUN device is not open";
     return false;
   }
 
@@ -246,11 +271,11 @@ bool TunnelForwarder::StartForwarding(int tun_fd, ForwarderErrorCallback on_erro
     on_error_ = std::move(on_error);
   }
 
-  tun_fd_ = tun_fd;
+  tun_backend_ = tun_backend;
   running_.store(true);
   tun_writes_.store(0);
   ssl_reads_.store(0);
-  tuntap::FwdDebug("forwarder-start", "mtu=%zu tunFd=%d", mtu_, tun_fd);
+  tuntap::FwdDebug("forwarder-start", "mtu=%zu tunFd=%d", mtu_, tun_backend->GetNativeFd());
   tun_thread_ = std::thread(&TunnelForwarder::TunToDeviceLoop, this);
   sock_thread_ = std::thread(&TunnelForwarder::DeviceToTunLoop, this);
   return true;
@@ -279,7 +304,7 @@ void TunnelForwarder::Stop() {
   }
 
   ssl_.Close();
-  tun_fd_ = -1;
+  tun_backend_ = nullptr;
 }
 
 ssize_t TunnelForwarder::SslReadChunk(uint8_t* buf, size_t max_len, bool only_while_running) {
@@ -321,7 +346,7 @@ ssize_t TunnelForwarder::SslReadChunk(uint8_t* buf, size_t max_len, bool only_wh
         return -1;
       }
       fd = SSL_get_fd(ssl);
-      poll_events = (err == SSL_ERROR_WANT_READ) ? POLLIN : POLLOUT;
+      poll_events = (err == SSL_ERROR_WANT_READ) ? kPollIn : kPollOut;
     }
 
     const std::atomic<bool>* running = only_while_running ? &running_ : nullptr;
@@ -380,7 +405,7 @@ ssize_t TunnelForwarder::SslWriteAll(const uint8_t* data, size_t len, bool only_
         return -1;
       }
       fd = SSL_get_fd(ssl);
-      poll_events = (err == SSL_ERROR_WANT_READ) ? POLLIN : POLLOUT;
+      poll_events = (err == SSL_ERROR_WANT_READ) ? kPollIn : kPollOut;
     }
 
     const std::atomic<bool>* running = only_while_running ? &running_ : nullptr;
@@ -392,94 +417,66 @@ ssize_t TunnelForwarder::SslWriteAll(const uint8_t* data, size_t len, bool only_
 }
 
 TunReadResult TunnelForwarder::ReadTunPacket(std::vector<uint8_t>& out) {
-#ifdef __APPLE__
-  uint8_t frame[4 + 65535];
-  const size_t cap = 4 + mtu_;
-#else
-  uint8_t frame[65535];
-  const size_t cap = mtu_;
-#endif
-
-  const ssize_t n = ::read(tun_fd_, frame, cap);
-  if (n > 0) {
-#ifdef __APPLE__
-    if (n <= static_cast<ssize_t>(kUtunHeaderSize)) {
-      return TunReadResult::kWouldBlock;
-    }
-    out.assign(frame + kUtunHeaderSize, frame + n);
-#else
-    out.assign(frame, frame + n);
-#endif
-    return TunReadResult::kOk;
-  }
-  if (n == 0) {
+  if (tun_backend_ == nullptr) {
     return TunReadResult::kFatal;
   }
-  if (errno == EINTR) {
-    return TunReadResult::kWouldBlock;
-  }
-  if (errno == EAGAIN || errno == EWOULDBLOCK) {
-    tuntap::FwdDebug("forwarder-tun-poll", "fd=%d", tun_fd_);
-    if (!PollFd(tun_fd_, POLLIN, &running_, TimePoint::max())) {
+
+  std::string error;
+  const ReadPacketStatus status = tun_backend_->ReadPacket(mtu_, out, error);
+  switch (status) {
+    case ReadPacketStatus::Data:
+      return TunReadResult::kOk;
+    case ReadPacketStatus::NoData:
+      tuntap::FwdDebug("forwarder-tun-wait", "fd=%d", tun_backend_->GetNativeFd());
+      if (!tun_backend_->WaitReadable(running_, error)) {
+        if (!error.empty()) {
+          tuntap::FwdDebug("forwarder-tun-wait-error", "%s", error.c_str());
+        }
+        return running_.load() ? TunReadResult::kFatal : TunReadResult::kWouldBlock;
+      }
+      return TunReadResult::kWouldBlock;
+    case ReadPacketStatus::Closed:
       return running_.load() ? TunReadResult::kFatal : TunReadResult::kWouldBlock;
-    }
-    return TunReadResult::kWouldBlock;
+    case ReadPacketStatus::Error:
+      if (!error.empty()) {
+        tuntap::FwdDebug("forwarder-tun-read-error", "%s", error.c_str());
+      }
+      return running_.load() ? TunReadResult::kFatal : TunReadResult::kWouldBlock;
   }
-  return running_.load() ? TunReadResult::kFatal : TunReadResult::kWouldBlock;
+
+  return TunReadResult::kFatal;
 }
 
 ssize_t TunnelForwarder::WriteTunPacket(const uint8_t* data, size_t len) {
-#ifdef __APPLE__
-  std::vector<uint8_t> frame(len + kUtunHeaderSize);
-  const uint32_t family = htonl(AF_INET6);
-  std::memcpy(frame.data(), &family, kUtunHeaderSize);
-  std::memcpy(frame.data() + kUtunHeaderSize, data, len);
-  size_t offset = 0;
-  while (offset < frame.size()) {
-    const ssize_t n = ::write(tun_fd_, frame.data() + offset, frame.size() - offset);
-    if (n < 0) {
-      if (errno == EINTR) {
-        continue;
-      }
-      if (errno == EAGAIN || errno == EWOULDBLOCK) {
-        tuntap::FwdDebug("forwarder-tun-write-blocked", "fd=%d", tun_fd_);
-        if (!PollFd(tun_fd_, POLLOUT, &running_, TimePoint::max())) {
-          return -1;
-        }
-        continue;
-      }
-      return -1;
-    }
-    if (n == 0) {
-      return -1;
-    }
-    offset += static_cast<size_t>(n);
+  if (tun_backend_ == nullptr) {
+    return -1;
   }
-  return static_cast<ssize_t>(len);
-#else
-  size_t offset = 0;
-  while (offset < len) {
-    const ssize_t n = ::write(tun_fd_, data + offset, len - offset);
+
+  for (;;) {
+    std::string error;
+    const ssize_t n = tun_backend_->WritePacket(data, len, error);
+    if (n == static_cast<ssize_t>(len)) {
+      return n;
+    }
     if (n < 0) {
-      if (errno == EINTR) {
-        continue;
-      }
-      if (errno == EAGAIN || errno == EWOULDBLOCK) {
-        tuntap::FwdDebug("forwarder-tun-write-blocked", "fd=%d", tun_fd_);
-        if (!PollFd(tun_fd_, POLLOUT, &running_, TimePoint::max())) {
-          return -1;
-        }
-        continue;
+      if (!error.empty()) {
+        tuntap::FwdDebug("forwarder-tun-write-error", "%s", error.c_str());
       }
       return -1;
     }
-    if (n == 0) {
+    if (n > 0) {
+      tuntap::FwdDebug("forwarder-tun-write-short", "expected=%zu actual=%zd", len, n);
       return -1;
     }
-    offset += static_cast<size_t>(n);
+
+    tuntap::FwdDebug("forwarder-tun-write-blocked", "fd=%d", tun_backend_->GetNativeFd());
+    if (!tun_backend_->WaitWritable(running_, error)) {
+      if (!error.empty()) {
+        tuntap::FwdDebug("forwarder-tun-write-wait-error", "%s", error.c_str());
+      }
+      return -1;
+    }
   }
-  return static_cast<ssize_t>(len);
-#endif
 }
 
 void TunnelForwarder::TunToDeviceLoop() {
@@ -671,8 +668,8 @@ private:
 
   Napi::Value StartForwarding(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
-    if (info.Length() < 1 || !info[0].IsNumber()) {
-      Napi::TypeError::New(env, "Expected (tunFd[, onError])").ThrowAsJavaScriptException();
+    if (info.Length() < 1 || !info[0].IsExternal()) {
+      Napi::TypeError::New(env, "Expected (tunForwardingHandle[, onError])").ThrowAsJavaScriptException();
       return env.Undefined();
     }
 
@@ -689,10 +686,10 @@ private:
                                                 0,
                                                 1);
 
-    const int tun_fd = info[0].As<Napi::Number>().Int32Value();
+    TunPlatformBackend* tun_backend = info[0].As<Napi::External<TunPlatformBackend>>().Data();
     std::string error;
     ForwarderErrorCallback callback = [this](std::string msg) { ReportError(std::move(msg)); };
-    if (!forwarder_.StartForwarding(tun_fd, std::move(callback), error)) {
+    if (!forwarder_.StartForwarding(tun_backend, std::move(callback), error)) {
       ReleaseErrorTsfn();
       Napi::Error::New(env, error).ThrowAsJavaScriptException();
     }
@@ -712,5 +709,3 @@ private:
 Napi::Object InitTunnelForwarder(Napi::Env env, Napi::Object exports) {
   return TunnelForwarderWrap::Init(env, exports);
 }
-
-#endif

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -14,6 +14,7 @@
 #include <winsock2.h>
 #include <uv.h>
 #include <v8.h>
+#include <v8-version.h>
 #endif
 
 #include <openssl/err.h>
@@ -62,6 +63,14 @@ bool TryReadUvHandle(void* wrapper, size_t offset, uv_tcp_t** out) {
   return matched;
 }
 
+void* GetNodeBaseObjectWrapper(v8::Local<v8::Object> object) {
+#if V8_MAJOR_VERSION >= 14
+  return object->GetAlignedPointerFromInternalField(1, v8::kEmbedderDataTypeTagDefault);
+#else
+  return object->GetAlignedPointerFromInternalField(1);
+#endif
+}
+
 bool ExtractTcpFdFromNodeHandle(const Napi::Value& value, int& fd, std::string& error) {
   if (!value.IsObject()) {
     error = "Expected Node TCP handle object";
@@ -83,7 +92,7 @@ bool ExtractTcpFdFromNodeHandle(const Napi::Value& value, int& fd, std::string& 
   // Node BaseObject stores an embedder tag in field 0 and the C++ wrapper in
   // BaseObject::kSlot (field 1). TCPWrap is private, so avoid including Node
   // internals and only use this stable internal-field convention.
-  void* wrapper = handle_obj->GetAlignedPointerFromInternalField(1);
+  void* wrapper = GetNodeBaseObjectWrapper(handle_obj);
   if (wrapper == nullptr) {
     error = "Node TCP handle internal wrapper is null";
     return false;

--- a/src/native/tunnel_forwarder.h
+++ b/src/native/tunnel_forwarder.h
@@ -79,6 +79,7 @@ private:
   size_t mtu_ = 1280;
   std::atomic<bool> running_{false};
   std::atomic<uint64_t> tun_writes_{0};
+  std::atomic<uint64_t> tun_drops_{0};
   std::atomic<uint64_t> ssl_reads_{0};
   std::chrono::steady_clock::time_point handshake_deadline_{};
   std::thread tun_thread_;

--- a/src/native/tunnel_forwarder.h
+++ b/src/native/tunnel_forwarder.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#if defined(__APPLE__) || defined(__linux__)
-
 #include <atomic>
 #include <chrono>
 #include <cstdint>
@@ -13,6 +11,7 @@
 
 #include <napi.h>
 
+#include "tun_backend.h"
 #include "tunnel_ssl.h"
 
 struct TunnelHandshakeInfo {
@@ -55,7 +54,9 @@ public:
 
   bool Handshake(uint32_t requested_mtu, TunnelHandshakeInfo& info, std::string& error);
 
-  bool StartForwarding(int tun_fd, ForwarderErrorCallback on_error, std::string& error);
+  bool StartForwarding(TunPlatformBackend* tun_backend,
+                       ForwarderErrorCallback on_error,
+                       std::string& error);
 
   void Stop();
 
@@ -74,7 +75,7 @@ private:
   std::mutex error_mutex_;
   ForwarderErrorCallback on_error_;
   std::atomic<bool> error_reported_{false};
-  int tun_fd_ = -1;
+  TunPlatformBackend* tun_backend_ = nullptr;
   size_t mtu_ = 1280;
   std::atomic<bool> running_{false};
   std::atomic<uint64_t> tun_writes_{0};
@@ -85,5 +86,3 @@ private:
 };
 
 Napi::Object InitTunnelForwarder(Napi::Env env, Napi::Object exports);
-
-#endif

--- a/src/native/tunnel_ssl.cc
+++ b/src/native/tunnel_ssl.cc
@@ -1,11 +1,13 @@
-#if defined(__APPLE__) || defined(__linux__)
-
 #include "tunnel_ssl.h"
 #include "debug_log.h"
 
+#ifdef _WIN32
+#include <winsock2.h>
+#else
 #include <fcntl.h>
 #include <poll.h>
 #include <unistd.h>
+#endif
 
 #include <chrono>
 #include <cerrno>
@@ -22,6 +24,14 @@ namespace {
 
 constexpr char kAppleTvPskCiphers[] =
     "PSK-AES256-CBC-SHA:PSK-AES128-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-RC4-SHA:PSK";
+
+#ifdef _WIN32
+constexpr short kPollIn = POLLRDNORM;
+constexpr short kPollOut = POLLWRNORM;
+#else
+constexpr short kPollIn = POLLIN;
+constexpr short kPollOut = POLLOUT;
+#endif
 
 bool LoadPem(SSL_CTX* ctx, const std::string& pem, bool is_cert, std::string& error) {
   BIO* bio = BIO_new_mem_buf(pem.data(), static_cast<int>(pem.size()));
@@ -58,15 +68,25 @@ bool LoadPem(SSL_CTX* ctx, const std::string& pem, bool is_cert, std::string& er
 }
 
 void SetNonBlockingFd(int fd) {
+#ifdef _WIN32
+  u_long mode = 1;
+  ioctlsocket(static_cast<SOCKET>(fd), FIONBIO, &mode);
+#else
   const int flags = fcntl(fd, F_GETFL, 0);
   if (flags >= 0) {
     fcntl(fd, F_SETFL, flags | O_NONBLOCK);
   }
+#endif
 }
 
 bool PollConnectFd(int fd, short events, std::chrono::steady_clock::time_point deadline) {
+#ifdef _WIN32
+  WSAPOLLFD pfd {};
+  pfd.fd = static_cast<SOCKET>(fd);
+#else
   struct pollfd pfd {};
   pfd.fd = fd;
+#endif
   pfd.events = events;
   using Clock = std::chrono::steady_clock;
   for (;;) {
@@ -77,9 +97,17 @@ bool PollConnectFd(int fd, short events, std::chrono::steady_clock::time_point d
     const auto remaining_ms =
         std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now).count();
     const int timeout_ms = remaining_ms > 5000 ? 5000 : static_cast<int>(remaining_ms);
+#ifdef _WIN32
+    const int rc = WSAPoll(&pfd, 1, timeout_ms);
+#else
     const int rc = poll(&pfd, 1, timeout_ms);
+#endif
     if (rc > 0) {
-      if ((pfd.revents & (POLLERR | POLLHUP | POLLNVAL)) != 0) {
+      if ((pfd.revents & (POLLERR | POLLHUP
+#ifndef _WIN32
+                          | POLLNVAL
+#endif
+                          )) != 0) {
         return false;
       }
       return (pfd.revents & events) != 0;
@@ -87,7 +115,11 @@ bool PollConnectFd(int fd, short events, std::chrono::steady_clock::time_point d
     if (rc == 0) {
       continue;
     }
+#ifdef _WIN32
+    if (WSAGetLastError() == WSAEINTR) {
+#else
     if (errno == EINTR) {
+#endif
       continue;
     }
     return false;
@@ -143,14 +175,14 @@ bool TunnelSslClient::ConnectTls(int timeout_ms, std::string& error) {
     }
     const int err = SSL_get_error(ssl_, rc);
     if (err == SSL_ERROR_WANT_READ) {
-      if (!PollConnectFd(owned_fd_, POLLIN, connect_deadline)) {
+      if (!PollConnectFd(owned_fd_, kPollIn, connect_deadline)) {
         error = "SSL_connect timed out waiting to read";
         return false;
       }
       continue;
     }
     if (err == SSL_ERROR_WANT_WRITE) {
-      if (!PollConnectFd(owned_fd_, POLLOUT, connect_deadline)) {
+      if (!PollConnectFd(owned_fd_, kPollOut, connect_deadline)) {
         error = "SSL_connect timed out waiting to write";
         return false;
       }
@@ -182,9 +214,15 @@ bool TunnelSslClient::Connect(int tcp_fd,
   }
 #endif
 
+  close_owned_fd_ = true;
+#ifdef _WIN32
+  owned_fd_ = tcp_fd;
+  close_owned_fd_ = false;
+#else
   owned_fd_ = dup(tcp_fd);
+#endif
   if (owned_fd_ < 0) {
-    error = "Failed to duplicate TCP file descriptor";
+    error = "Failed to acquire TCP socket handle";
     return false;
   }
   SetNonBlockingFd(owned_fd_);
@@ -253,9 +291,15 @@ bool TunnelSslClient::ConnectPsk(int tcp_fd,
   }
 #endif
 
+  close_owned_fd_ = true;
+#ifdef _WIN32
+  owned_fd_ = tcp_fd;
+  close_owned_fd_ = false;
+#else
   owned_fd_ = dup(tcp_fd);
+#endif
   if (owned_fd_ < 0) {
-    error = "Failed to duplicate TCP file descriptor";
+    error = "Failed to acquire TCP socket handle";
     return false;
   }
   SetNonBlockingFd(owned_fd_);
@@ -305,12 +349,17 @@ void TunnelSslClient::Close() {
     SSL_CTX_free(ctx_);
     ctx_ = nullptr;
   }
-  if (owned_fd_ >= 0) {
+  if (owned_fd_ >= 0 && close_owned_fd_) {
+#ifdef _WIN32
+    closesocket(static_cast<SOCKET>(owned_fd_));
+#else
     ::close(owned_fd_);
+#endif
+  }
+  if (owned_fd_ >= 0) {
     owned_fd_ = -1;
   }
+  close_owned_fd_ = true;
   psk_key_.clear();
   psk_identity_.clear();
 }
-
-#endif

--- a/src/native/tunnel_ssl.cc
+++ b/src/native/tunnel_ssl.cc
@@ -3,6 +3,7 @@
 
 #ifdef _WIN32
 #include <winsock2.h>
+#include <windows.h>
 #else
 #include <fcntl.h>
 #include <poll.h>
@@ -78,6 +79,35 @@ void SetNonBlockingFd(int fd) {
   }
 #endif
 }
+
+#ifdef _WIN32
+int DuplicateSocketFd(int tcp_fd, std::string& error) {
+  if (tcp_fd < 0) {
+    error = "Invalid TCP socket handle";
+    return -1;
+  }
+
+  WSAPROTOCOL_INFOW protocol_info {};
+  if (WSADuplicateSocketW(static_cast<SOCKET>(tcp_fd), ::GetCurrentProcessId(), &protocol_info) !=
+      0) {
+    error = "WSADuplicateSocket failed: " + std::to_string(WSAGetLastError());
+    return -1;
+  }
+
+  SOCKET duplicated = WSASocketW(protocol_info.iAddressFamily,
+                                 protocol_info.iSocketType,
+                                 protocol_info.iProtocol,
+                                 &protocol_info,
+                                 0,
+                                 WSA_FLAG_OVERLAPPED);
+  if (duplicated == INVALID_SOCKET) {
+    error = "WSASocket duplicate failed: " + std::to_string(WSAGetLastError());
+    return -1;
+  }
+
+  return static_cast<int>(duplicated);
+}
+#endif
 
 bool PollConnectFd(int fd, short events, std::chrono::steady_clock::time_point deadline) {
 #ifdef _WIN32
@@ -216,8 +246,7 @@ bool TunnelSslClient::Connect(int tcp_fd,
 
   close_owned_fd_ = true;
 #ifdef _WIN32
-  owned_fd_ = tcp_fd;
-  close_owned_fd_ = false;
+  owned_fd_ = DuplicateSocketFd(tcp_fd, error);
 #else
   owned_fd_ = dup(tcp_fd);
 #endif
@@ -293,8 +322,7 @@ bool TunnelSslClient::ConnectPsk(int tcp_fd,
 
   close_owned_fd_ = true;
 #ifdef _WIN32
-  owned_fd_ = tcp_fd;
-  close_owned_fd_ = false;
+  owned_fd_ = DuplicateSocketFd(tcp_fd, error);
 #else
   owned_fd_ = dup(tcp_fd);
 #endif

--- a/src/native/tunnel_ssl.h
+++ b/src/native/tunnel_ssl.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#if defined(__APPLE__) || defined(__linux__)
-
 #include <cstddef>
 #include <cstdint>
 #include <openssl/ssl.h>
@@ -51,8 +49,7 @@ private:
   SSL_CTX* ctx_ = nullptr;
   SSL* ssl_ = nullptr;
   int owned_fd_ = -1;
+  bool close_owned_fd_ = true;
   std::vector<uint8_t> psk_key_;
   std::string psk_identity_;
 };
-
-#endif

--- a/src/platform/windows.ts
+++ b/src/platform/windows.ts
@@ -1,4 +1,5 @@
 import type {ExecException} from 'node:child_process';
+import {performance} from 'node:perf_hooks';
 
 import {TunTapError} from '../errors.js';
 import {log} from '../logger.js';
@@ -140,10 +141,10 @@ async function addIpv6Address(interfaceName: string, address: string): Promise<v
 }
 
 async function waitForIpv6AddressReady(interfaceName: string, address: string): Promise<void> {
-  const deadline = Date.now() + ADDRESS_READY_TIMEOUT_MS;
+  const deadline = performance.now() + ADDRESS_READY_TIMEOUT_MS;
   let lastState = '';
 
-  while (Date.now() < deadline) {
+  while (performance.now() < deadline) {
     const escapedName = interfaceName.replace(/'/g, '\'\'');
     const escapedAddress = address.replace(/'/g, '\'\'');
     const script =

--- a/src/platform/windows.ts
+++ b/src/platform/windows.ts
@@ -159,15 +159,19 @@ async function waitForIpv6AddressReady(interfaceName: string, address: string): 
       script,
     ]);
     lastState = stdout.trim();
-    if (!lastState || /^Preferred$/i.test(lastState)) {
-      tunDebug(`[win] address ready: ${address} state=${lastState || '(unknown)'}`);
+    if (/^Preferred$/i.test(lastState)) {
+      tunDebug(`[win] address ready: ${address} state=${lastState}`);
       return;
     }
-    tunDebug(`[win] waiting for address: ${address} state=${lastState}`);
+    tunDebug(`[win] waiting for address: ${address} state=${lastState || '(not found)'}`);
     await new Promise((resolve) => setTimeout(resolve, 100));
   }
 
-  log.warn(`[win] address ${address} did not become Preferred (last state: ${lastState})`);
+  throw new TunTapError(
+    `[win] address ${address} did not become Preferred (last state: ${
+      lastState || 'not found'
+    })`,
+  );
 }
 
 async function setIpv6Mtu(interfaceName: string, mtu: number): Promise<void> {

--- a/src/platform/windows.ts
+++ b/src/platform/windows.ts
@@ -19,6 +19,8 @@ const MISSING_TARGET_HINTS = [
   'not found',
 ];
 
+const ADDRESS_READY_TIMEOUT_MS = 5000;
+
 /** Windows implementation backed by `netsh` for configuration/routing and
  *  PowerShell `Get-NetAdapterStatistics` for byte counters. */
 export class WindowsTunTapPlatform implements TunTapPlatform {
@@ -29,6 +31,7 @@ export class WindowsTunTapPlatform implements TunTapPlatform {
     tunDebug(`[win] configure: interface=${interfaceName} address=${address} mtu=${mtu}`);
 
     await addIpv6Address(interfaceName, address);
+    await waitForIpv6AddressReady(interfaceName, address);
     await setIpv6Mtu(interfaceName, mtu);
   }
 
@@ -134,6 +137,37 @@ async function addIpv6Address(interfaceName: string, address: string): Promise<v
     }
     log.warn(`Address ${address} may already be configured on ${interfaceName}`);
   }
+}
+
+async function waitForIpv6AddressReady(interfaceName: string, address: string): Promise<void> {
+  const deadline = Date.now() + ADDRESS_READY_TIMEOUT_MS;
+  let lastState = '';
+
+  while (Date.now() < deadline) {
+    const escapedName = interfaceName.replace(/'/g, '\'\'');
+    const escapedAddress = address.replace(/'/g, '\'\'');
+    const script =
+      `Get-NetIPAddress -InterfaceAlias '${escapedName}' -IPAddress '${escapedAddress}' ` +
+      '-AddressFamily IPv6 -ErrorAction SilentlyContinue | ' +
+      'Select-Object -First 1 -ExpandProperty AddressState';
+    const {stdout} = await execFileAsync('powershell', [
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-Command',
+      script,
+    ]);
+    lastState = stdout.trim();
+    if (!lastState || /^Preferred$/i.test(lastState)) {
+      tunDebug(`[win] address ready: ${address} state=${lastState || '(unknown)'}`);
+      return;
+    }
+    tunDebug(`[win] waiting for address: ${address} state=${lastState}`);
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+
+  log.warn(`[win] address ${address} did not become Preferred (last state: ${lastState})`);
 }
 
 async function setIpv6Mtu(interfaceName: string, mtu: number): Promise<void> {

--- a/src/platform/windows.ts
+++ b/src/platform/windows.ts
@@ -145,8 +145,8 @@ async function waitForIpv6AddressReady(interfaceName: string, address: string): 
   let lastState = '';
 
   while (performance.now() < deadline) {
-    const escapedName = interfaceName.replace(/'/g, '\'\'');
-    const escapedAddress = address.replace(/'/g, '\'\'');
+    const escapedName = interfaceName.replace(/'/g, "''");
+    const escapedAddress = address.replace(/'/g, "''");
     const script =
       `Get-NetIPAddress -InterfaceAlias '${escapedName}' -IPAddress '${escapedAddress}' ` +
       '-AddressFamily IPv6 -ErrorAction SilentlyContinue | ' +
@@ -169,9 +169,7 @@ async function waitForIpv6AddressReady(interfaceName: string, address: string): 
   }
 
   throw new TunTapError(
-    `[win] address ${address} did not become Preferred (last state: ${
-      lastState || 'not found'
-    })`,
+    `[win] address ${address} did not become Preferred (last state: ${lastState || 'not found'})`,
   );
 }
 

--- a/src/tunnel/forwarder.ts
+++ b/src/tunnel/forwarder.ts
@@ -71,7 +71,11 @@ export class TunnelForwarder {
         credentials.identity ?? '',
       );
     } else {
-      this.forwarder.connectPsk(getSocketFd(tcpSocket), credentials.psk, credentials.identity ?? '');
+      this.forwarder.connectPsk(
+        getSocketFd(tcpSocket),
+        credentials.psk,
+        credentials.identity ?? '',
+      );
     }
 
     this.takeSocketOwnership(tcpSocket);

--- a/src/tunnel/forwarder.ts
+++ b/src/tunnel/forwarder.ts
@@ -24,7 +24,9 @@ export interface TunnelPskTlsCredentials {
 
 interface NativeTunnelForwarder {
   connect(tcpFd: number, certPem: string, keyPem: string): void;
+  connectSocket(tcpHandle: unknown, certPem: string, keyPem: string): void;
   connectPsk(tcpFd: number, psk: Buffer, identity?: string): void;
+  connectPskSocket(tcpHandle: unknown, psk: Buffer, identity?: string): void;
   handshake(requestedMtu: number): TunnelInfo;
   startForwarding(tunForwardingHandle: unknown, onError?: (message: string) => void): void;
   stop(): void;
@@ -42,25 +44,35 @@ export class TunnelForwarder {
   private retainedSocket: Socket | null = null;
 
   connect(tcpSocket: Socket, credentials: TunnelLockdownTlsCredentials): void {
-    const tcpFd = getSocketFd(tcpSocket);
     tcpSocket.pause();
     tcpSocket.removeAllListeners();
 
     const native = require('node-gyp-build')(pkgRoot) as NativeTuntapModule;
     this.forwarder = new native.TunnelForwarder();
-    this.forwarder.connect(tcpFd, credentials.cert, credentials.key);
+    if (process.platform === 'win32') {
+      this.forwarder.connectSocket(getSocketHandle(tcpSocket), credentials.cert, credentials.key);
+    } else {
+      this.forwarder.connect(getSocketFd(tcpSocket), credentials.cert, credentials.key);
+    }
 
     this.takeSocketOwnership(tcpSocket);
   }
 
   connectPsk(tcpSocket: Socket, credentials: TunnelPskTlsCredentials): void {
-    const tcpFd = getSocketFd(tcpSocket);
     tcpSocket.pause();
     tcpSocket.removeAllListeners();
 
     const native = require('node-gyp-build')(pkgRoot) as NativeTuntapModule;
     this.forwarder = new native.TunnelForwarder();
-    this.forwarder.connectPsk(tcpFd, credentials.psk, credentials.identity ?? '');
+    if (process.platform === 'win32') {
+      this.forwarder.connectPskSocket(
+        getSocketHandle(tcpSocket),
+        credentials.psk,
+        credentials.identity ?? '',
+      );
+    } else {
+      this.forwarder.connectPsk(getSocketFd(tcpSocket), credentials.psk, credentials.identity ?? '');
+    }
 
     this.takeSocketOwnership(tcpSocket);
   }
@@ -94,11 +106,7 @@ export class TunnelForwarder {
   }
 
   private takeSocketOwnership(socket: Socket): void {
-    if (process.platform === 'win32') {
-      this.retainedSocket = socket;
-    } else {
-      destroySocket(socket);
-    }
+    destroySocket(socket);
   }
 }
 
@@ -108,6 +116,14 @@ function getSocketFd(socket: Socket): number {
     return handle.fd;
   }
   throw new Error('TCP socket file descriptor is not available');
+}
+
+function getSocketHandle(socket: Socket): unknown {
+  const handle = (socket as {_handle?: unknown})._handle;
+  if (handle) {
+    return handle;
+  }
+  throw new Error('TCP socket handle is not available');
 }
 
 function destroySocket(socket: Socket): void {

--- a/src/tunnel/forwarder.ts
+++ b/src/tunnel/forwarder.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 import type {Socket} from 'node:net';
 
+import type {TunTap} from '../TunTap.js';
 import type {TunnelInfo} from './types.js';
 
 const require = createRequire(import.meta.url);
@@ -25,7 +26,7 @@ interface NativeTunnelForwarder {
   connect(tcpFd: number, certPem: string, keyPem: string): void;
   connectPsk(tcpFd: number, psk: Buffer, identity?: string): void;
   handshake(requestedMtu: number): TunnelInfo;
-  startForwarding(tunFd: number, onError?: (message: string) => void): void;
+  startForwarding(tunForwardingHandle: unknown, onError?: (message: string) => void): void;
   stop(): void;
 }
 
@@ -38,12 +39,9 @@ interface NativeTuntapModule {
  */
 export class TunnelForwarder {
   private forwarder: NativeTunnelForwarder | null = null;
+  private retainedSocket: Socket | null = null;
 
   connect(tcpSocket: Socket, credentials: TunnelLockdownTlsCredentials): void {
-    if (process.platform === 'win32') {
-      throw new Error('Native tunnel forwarder is not supported on Windows');
-    }
-
     const tcpFd = getSocketFd(tcpSocket);
     tcpSocket.pause();
     tcpSocket.removeAllListeners();
@@ -52,14 +50,10 @@ export class TunnelForwarder {
     this.forwarder = new native.TunnelForwarder();
     this.forwarder.connect(tcpFd, credentials.cert, credentials.key);
 
-    destroySocket(tcpSocket);
+    this.takeSocketOwnership(tcpSocket);
   }
 
   connectPsk(tcpSocket: Socket, credentials: TunnelPskTlsCredentials): void {
-    if (process.platform === 'win32') {
-      throw new Error('Native tunnel forwarder is not supported on Windows');
-    }
-
     const tcpFd = getSocketFd(tcpSocket);
     tcpSocket.pause();
     tcpSocket.removeAllListeners();
@@ -68,7 +62,7 @@ export class TunnelForwarder {
     this.forwarder = new native.TunnelForwarder();
     this.forwarder.connectPsk(tcpFd, credentials.psk, credentials.identity ?? '');
 
-    destroySocket(tcpSocket);
+    this.takeSocketOwnership(tcpSocket);
   }
 
   handshake(requestedMtu: number): TunnelInfo {
@@ -78,23 +72,33 @@ export class TunnelForwarder {
     return this.forwarder.handshake(requestedMtu);
   }
 
-  startForwarding(tunFd: number, onError?: (message: string) => void): void {
+  startForwarding(tun: TunTap, onError?: (message: string) => void): void {
     if (!this.forwarder) {
       throw new Error('Tunnel forwarder is not connected');
     }
-    if (tunFd < 0) {
-      throw new Error('TUN file descriptor is not available');
-    }
+    const forwardingHandle = tun.forwardingHandle;
     if (onError) {
-      this.forwarder.startForwarding(tunFd, onError);
+      this.forwarder.startForwarding(forwardingHandle, onError);
     } else {
-      this.forwarder.startForwarding(tunFd);
+      this.forwarder.startForwarding(forwardingHandle);
     }
   }
 
   stop(): void {
     this.forwarder?.stop();
     this.forwarder = null;
+    if (this.retainedSocket) {
+      destroySocket(this.retainedSocket);
+      this.retainedSocket = null;
+    }
+  }
+
+  private takeSocketOwnership(socket: Socket): void {
+    if (process.platform === 'win32') {
+      this.retainedSocket = socket;
+    } else {
+      destroySocket(socket);
+    }
   }
 }
 

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -119,7 +119,13 @@ export class TunnelManager {
 
     this.cancelled = true;
 
-    // Close TUN first so native forwarder threads unblock on read/write.
+    // Stop the native forwarder before closing TUN: it holds a raw backend
+    // pointer while its worker threads are running.
+    if (this.forwarder) {
+      this.forwarder.stop();
+      this.forwarder = null;
+    }
+
     if (this.tun) {
       try {
         this.tun.close();
@@ -127,11 +133,6 @@ export class TunnelManager {
         log.error('Error closing TUN device:', err);
       }
       this.tun = null;
-    }
-
-    if (this.forwarder) {
-      this.forwarder.stop();
-      this.forwarder = null;
     }
 
     tunDebug(`Tunnel for ${tunName} closed successfully`);

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -84,7 +84,7 @@ export class TunnelManager {
 
     tunDebug(`Starting OpenSSL tunnel forwarding for ${this.tun.name}`);
     this.forwarder = forwarder;
-    forwarder.startForwarding(this.tun.fd, (message) => {
+    forwarder.startForwarding(this.tun, (message) => {
       if (this.cancelled) {
         tunDebug(`Ignoring forwarder error during shutdown: ${message}`);
         return;
@@ -182,10 +182,6 @@ async function connectTunnel(
   setupTls: (forwarder: TunnelForwarder) => void,
   onDead?: (reason: string) => void,
 ): Promise<TunnelConnection> {
-  if (process.platform === 'win32') {
-    throw new Error('Native OpenSSL tunnel forwarder is not supported on Windows');
-  }
-
   const tunnelManager = new TunnelManager();
   const forwarder = new TunnelForwarder();
 

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -9,10 +9,7 @@
 #include <deque>
 
 #include "native/tun_backend.h"
-
-#if defined(__APPLE__) || defined(__linux__)
 #include "native/tunnel_forwarder.h"
-#endif
 
 struct TunPollDispatch {
   Napi::ThreadSafeFunction tsfn;
@@ -102,6 +99,7 @@ private:
   Napi::Value Write(const Napi::CallbackInfo& info);
   Napi::Value GetName(const Napi::CallbackInfo& info);
   Napi::Value GetFd(const Napi::CallbackInfo& info);
+  Napi::Value GetForwardingHandle(const Napi::CallbackInfo& info);
   Napi::Value StartPolling(const Napi::CallbackInfo& info);
   Napi::Value PausePolling(const Napi::CallbackInfo& info);
   Napi::Value ResumePolling(const Napi::CallbackInfo& info);
@@ -134,6 +132,7 @@ Napi::Object TunDevice::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod("write", &TunDevice::Write),
     InstanceMethod("getName", &TunDevice::GetName),
     InstanceMethod("getFd", &TunDevice::GetFd),
+    InstanceMethod("getForwardingHandle", &TunDevice::GetForwardingHandle),
     InstanceMethod("startPolling", &TunDevice::StartPolling),
     InstanceMethod("pausePolling", &TunDevice::PausePolling),
     InstanceMethod("resumePolling", &TunDevice::ResumePolling),
@@ -264,6 +263,18 @@ Napi::Value TunDevice::GetFd(const Napi::CallbackInfo& info) {
   return Napi::Number::New(info.Env(), backend_ ? backend_->GetNativeFd() : -1);
 }
 
+Napi::Value TunDevice::GetForwardingHandle(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  std::lock_guard<std::mutex> lock(device_mutex_);
+
+  if (!is_open_ || !backend_ || !backend_->IsOpen()) {
+    Napi::Error::New(env, "Device not open").ThrowAsJavaScriptException();
+    return env.Null();
+  }
+
+  return Napi::External<TunPlatformBackend>::New(env, backend_.get());
+}
+
 Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
   std::lock_guard<std::mutex> lock(device_mutex_);
@@ -378,9 +389,7 @@ Napi::Value TunDevice::ResumePolling(const Napi::CallbackInfo& info) {
 
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   TunDevice::Init(env, exports);
-#if defined(__APPLE__) || defined(__linux__)
   InitTunnelForwarder(env, exports);
-#endif
   return exports;
 }
 

--- a/test/integration/tuntap-integration.spec.mjs
+++ b/test/integration/tuntap-integration.spec.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import {spawn} from 'node:child_process';
 import path from 'node:path';
-import {afterEach, before, describe, it} from 'node:test';
+import {afterEach, describe, it} from 'node:test';
 import {fileURLToPath} from 'node:url';
 
 import {TunTap} from '../../lib/index.js';
@@ -9,19 +9,11 @@ import {hasPrivileges} from '../utils.mjs';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
+const hasRequiredPrivileges = await hasPrivileges();
+const skipWithoutPrivileges = getPrivilegeSkipReason(hasRequiredPrivileges);
 
 describe('TunTap Integration Tests', {timeout: 15000}, () => {
   let tun;
-
-  before(async () => {
-    if (!(await hasPrivileges())) {
-      throw new Error(
-        process.platform === 'win32'
-          ? 'Must be run from an elevated PowerShell (Run as administrator)'
-          : 'Must be run as root',
-      );
-    }
-  });
 
   describe('TunTap CLI Utility Signal Handling', {skip: process.platform === 'win32'}, () => {
     // Windows does not deliver POSIX signals to child processes the way Unix
@@ -58,7 +50,7 @@ describe('TunTap Integration Tests', {timeout: 15000}, () => {
     tun = null;
   });
 
-  it('should open, configure, add route, and close', async () => {
+  it('should open, configure, add route, and close', {skip: skipWithoutPrivileges}, async () => {
     tun = new TunTap();
     assert.strictEqual(tun.open(), true, 'TUN device should open');
     assert.strictEqual(typeof tun.name, 'string');
@@ -74,48 +66,56 @@ describe('TunTap Integration Tests', {timeout: 15000}, () => {
     assert.strictEqual(tun.close(), true, 'TUN device should close');
   });
 
-  it('should read and write data (simulate traffic)', {timeout: 10000}, async () => {
-    tun = new TunTap();
-    assert.strictEqual(tun.open(), true, 'TUN device should open');
-    await tun.configure('fd00::1', 1500);
-    await new Promise((resolve, reject) => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      let readCount = 0;
-      const timeout = setTimeout(() => {
-        tun.close();
-        resolve();
-      }, 3000);
+  it(
+    'should read and write data (simulate traffic)',
+    {timeout: 10000, skip: skipWithoutPrivileges},
+    async () => {
+      tun = new TunTap();
+      assert.strictEqual(tun.open(), true, 'TUN device should open');
+      await tun.configure('fd00::1', 1500);
+      await new Promise((resolve, reject) => {
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        let readCount = 0;
+        const timeout = setTimeout(() => {
+          tun.close();
+          resolve();
+        }, 3000);
 
-      const interval = setInterval(() => {
-        try {
-          const data = tun.read(4096);
-          if (data && data.length > 0) {
-            readCount++;
-            const bytesWritten = tun.write(data);
-            assert.strictEqual(bytesWritten, data.length, 'Should echo back same number of bytes');
+        const interval = setInterval(() => {
+          try {
+            const data = tun.read(4096);
+            if (data && data.length > 0) {
+              readCount++;
+              const bytesWritten = tun.write(data);
+              assert.strictEqual(
+                bytesWritten,
+                data.length,
+                'Should echo back same number of bytes',
+              );
+              clearTimeout(timeout);
+              clearInterval(interval);
+              tun.close();
+              resolve();
+            }
+          } catch (err) {
             clearTimeout(timeout);
             clearInterval(interval);
             tun.close();
-            resolve();
+            reject(err);
           }
-        } catch (err) {
-          clearTimeout(timeout);
-          clearInterval(interval);
-          tun.close();
-          reject(err);
-        }
-      }, 100);
-    });
-  });
+        }, 100);
+      });
+    },
+  );
 
-  it('should fail to open an already closed device', () => {
+  it('should fail to open an already closed device', {skip: skipWithoutPrivileges}, () => {
     tun = new TunTap();
     tun.open();
     tun.close();
     assert.throws(() => tun.open(), /Device has been closed/);
   });
 
-  it('should throw on invalid configuration', async () => {
+  it('should throw on invalid configuration', {skip: skipWithoutPrivileges}, async () => {
     tun = new TunTap();
     tun.open();
     await assert.rejects(() => tun.configure('not-an-ip', 1500), /Invalid IPv6 address/);
@@ -123,7 +123,7 @@ describe('TunTap Integration Tests', {timeout: 15000}, () => {
     tun.close();
   });
 
-  it('should get interface statistics', async () => {
+  it('should get interface statistics', {skip: skipWithoutPrivileges}, async () => {
     tun = new TunTap();
     tun.open();
     await tun.configure('fd00::1', 1500);
@@ -133,3 +133,12 @@ describe('TunTap Integration Tests', {timeout: 15000}, () => {
     tun.close();
   });
 });
+
+function getPrivilegeSkipReason(hasRequiredPrivileges) {
+  if (hasRequiredPrivileges) {
+    return false;
+  }
+  return process.platform === 'win32'
+    ? 'Requires Administrator privileges on Windows'
+    : 'Requires root privileges';
+}

--- a/test/integration/tuntap-integration.spec.mjs
+++ b/test/integration/tuntap-integration.spec.mjs
@@ -60,9 +60,9 @@ describe('TunTap Integration Tests', {timeout: 15000}, () => {
     }
 
     await tun.configure('fd00::1', 1500);
-    await tun.addRoute('fd00::/64');
+    await tun.addRoute('fd01::/64');
 
-    await tun.removeRoute('fd00::/64');
+    await tun.removeRoute('fd01::/64');
     assert.strictEqual(tun.close(), true, 'TUN device should close');
   });
 

--- a/test/unit/tuntap-unit.spec.mjs
+++ b/test/unit/tuntap-unit.spec.mjs
@@ -1,7 +1,7 @@
 import assert from 'node:assert';
 import {afterEach, before, describe, it} from 'node:test';
 
-import {TunTap} from '../../lib/index.js';
+import {TunTap, TunnelForwarder} from '../../lib/index.js';
 import {hasPrivileges} from '../utils.mjs';
 
 /**
@@ -29,6 +29,15 @@ describe('TunTap Unit Tests', {timeout: 10000}, () => {
       } catch {}
     }
     tun = null;
+  });
+
+  it('should expose the native tunnel forwarder', () => {
+    const forwarder = new TunnelForwarder();
+    assert.strictEqual(typeof forwarder.connect, 'function');
+    assert.strictEqual(typeof forwarder.connectPsk, 'function');
+    assert.strictEqual(typeof forwarder.handshake, 'function');
+    assert.strictEqual(typeof forwarder.startForwarding, 'function');
+    forwarder.stop();
   });
 
   it('should open and close the TUN device', () => {

--- a/test/unit/tuntap-unit.spec.mjs
+++ b/test/unit/tuntap-unit.spec.mjs
@@ -1,26 +1,19 @@
 import assert from 'node:assert';
-import {afterEach, before, describe, it} from 'node:test';
+import {afterEach, describe, it} from 'node:test';
 
 import {TunTap, TunnelForwarder} from '../../lib/index.js';
 import {hasPrivileges} from '../utils.mjs';
 
 /**
  * NOTE: Most TunTap tests require elevated privileges (root on POSIX,
- * Administrator on Windows). They fail fast otherwise.
+ * Administrator on Windows), so privileged cases are skipped when needed.
  */
+
+const hasRequiredPrivileges = await hasPrivileges();
+const skipWithoutPrivileges = getPrivilegeSkipReason(hasRequiredPrivileges);
 
 describe('TunTap Unit Tests', {timeout: 10000}, () => {
   let tun;
-
-  before(async () => {
-    if (!(await hasPrivileges())) {
-      throw new Error(
-        process.platform === 'win32'
-          ? 'Must be run from an elevated PowerShell (Run as administrator)'
-          : 'Must be run as root',
-      );
-    }
-  });
 
   afterEach(() => {
     if (tun && tun.isOpen && !tun.isClosed) {
@@ -40,7 +33,7 @@ describe('TunTap Unit Tests', {timeout: 10000}, () => {
     forwarder.stop();
   });
 
-  it('should open and close the TUN device', () => {
+  it('should open and close the TUN device', {skip: skipWithoutPrivileges}, () => {
     tun = new TunTap();
     assert.strictEqual(tun.open(), true, 'TUN device should open');
     assert.strictEqual(typeof tun.name, 'string');
@@ -57,14 +50,14 @@ describe('TunTap Unit Tests', {timeout: 10000}, () => {
     assert.throws(() => tun.write(Buffer.alloc(10)), /Device not open/);
   });
 
-  it('should throw if reopening after close', () => {
+  it('should throw if reopening after close', {skip: skipWithoutPrivileges}, () => {
     tun = new TunTap();
     tun.open();
     tun.close();
     assert.throws(() => tun.open(), /Device has been closed/);
   });
 
-  it('should handle configure and add/remove route', async () => {
+  it('should handle configure and add/remove route', {skip: skipWithoutPrivileges}, async () => {
     tun = new TunTap();
     tun.open();
     await tun.configure('fd00::2', 1500);
@@ -73,7 +66,7 @@ describe('TunTap Unit Tests', {timeout: 10000}, () => {
     tun.close();
   });
 
-  it('should not leave open handles after close', async () => {
+  it('should not leave open handles after close', {skip: skipWithoutPrivileges}, async () => {
     tun = new TunTap();
     tun.open();
     tun.close();
@@ -90,7 +83,7 @@ describe('TunTap Unit Tests', {timeout: 10000}, () => {
     assert.ok(handles.length <= 2, 'No extra handles should remain after close');
   });
 
-  it('should handle errors gracefully', async () => {
+  it('should handle errors gracefully', {skip: skipWithoutPrivileges}, async () => {
     tun = new TunTap();
     tun.open();
     await assert.rejects(() => tun.configure('invalid', 1500), /Invalid IPv6 address/);
@@ -98,3 +91,12 @@ describe('TunTap Unit Tests', {timeout: 10000}, () => {
     tun.close();
   });
 });
+
+function getPrivilegeSkipReason(hasRequiredPrivileges) {
+  if (hasRequiredPrivileges) {
+    return false;
+  }
+  return process.platform === 'win32'
+    ? 'Requires Administrator privileges on Windows'
+    : 'Requires root privileges';
+}

--- a/test/unit/tuntap-unit.spec.mjs
+++ b/test/unit/tuntap-unit.spec.mjs
@@ -61,8 +61,8 @@ describe('TunTap Unit Tests', {timeout: 10000}, () => {
     tun = new TunTap();
     tun.open();
     await tun.configure('fd00::2', 1500);
-    await tun.addRoute('fd00::/64');
-    await tun.removeRoute('fd00::/64');
+    await tun.addRoute('fd01::/64');
+    await tun.removeRoute('fd01::/64');
     tun.close();
   });
 


### PR DESCRIPTION
## Summary

- Enables stable Windows CoreDeviceProxy tunnel forwarding by duplicating the private Node/libuv socket handle for native OpenSSL ownership.
- Filters WinTun traffic so only valid unicast IPv6 packets are forwarded into CDTunnel, avoiding Windows multicast/NDP/non-IPv6 noise.
- Hardens Windows setup and teardown by waiting for the tunnel IPv6 address to become `Preferred`, synchronizing native error callback teardown, and documenting Apple Mobile Device driver requirements.

## Test Plan

- `npm run build`
- `npm run build:addon`
- `npm run lint`
- Manual Windows device test:
  - Started tunnel creation from elevated PowerShell.
  - Confirmed RSD catalog publication for connected iOS device.
  - Ran AFC tunnel stability test with `20` iterations and `1 MiB` payload:
    - `20/20 ok`
    - avg round-trip throughput: `16.92-17.62 MiB/s`