### PR TITLE
fix: replace V8-internals socket extraction with loopback bridge on Windows

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -122,7 +122,8 @@
             "src/native/wintun_loader.cc",
             "src/native/tun_backend_windows.cc",
             "src/native/tunnel_ssl.cc",
-            "src/native/tunnel_forwarder.cc"
+            "src/native/tunnel_forwarder.cc",
+            "src/native/win_delay_load_failure_hook.cc"
           ],
           "include_dirs": [
             "<(openssl_root)/include"

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -12,9 +12,7 @@
 #include <arpa/inet.h>
 #else
 #include <winsock2.h>
-#include <uv.h>
-#include <v8.h>
-#include <v8-version.h>
+#include <ws2tcpip.h>
 #endif
 
 #include <openssl/err.h>
@@ -40,95 +38,73 @@ using Clock = std::chrono::steady_clock;
 using TimePoint = Clock::time_point;
 
 #ifdef _WIN32
-v8::Local<v8::Value> ToV8Local(napi_value value) {
-  return *reinterpret_cast<v8::Local<v8::Value>*>(&value);
-}
+// Opens a plain TCP connection directly via WinSock, given a host/port.
+//
+// This exists so Windows callers never need to hand a JS net.Socket to the
+// native addon and have it try to recover the underlying OS socket. That
+// used to be done by reading V8's private internal-object layout to find
+// the embedded uv_tcp_t (net.Socket's own `_handle.fd` is hard-coded to -1
+// on Windows, unlike POSIX, because libuv wraps an opaque SOCKET there
+// rather than a POSIX fd) -- but V8's internal-field/pointer-tagging
+// layout is undocumented and not ABI-stable across V8 versions, so a
+// prebuild compiled against one Node/V8 build could fail to resolve the
+// symbols it needs on another (observed as an unhandled delay-load
+// ERROR_PROC_NOT_FOUND crash, exit code 0xC06D007F).
+//
+// Instead, the JS layer bridges its already-negotiated socket through a
+// local loopback listener (see forwarder.ts bridgeToNative) and passes that
+// listener's (host, port) here; this dials it with plain WinSock, so no
+// Node/V8 internals are involved at all.
+bool ConnectRawTcp(const std::string& host, uint16_t port, int& fd, std::string& error) {
+  struct addrinfo hints {};
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  hints.ai_protocol = IPPROTO_TCP;
 
-bool TryReadUvHandle(void* wrapper, size_t offset, uv_tcp_t** out) {
-  bool matched = false;
-#ifdef _MSC_VER
-  __try {
-#endif
-    auto* handle = reinterpret_cast<uv_handle_t*>(
-        reinterpret_cast<uintptr_t>(wrapper) + offset);
-    if (handle->type == UV_TCP && handle->data == wrapper) {
-      *out = reinterpret_cast<uv_tcp_t*>(handle);
-      matched = true;
+  struct addrinfo* resolved = nullptr;
+  const std::string port_str = std::to_string(port);
+  const int gai_rc = getaddrinfo(host.c_str(), port_str.c_str(), &hints, &resolved);
+  if (gai_rc != 0 || resolved == nullptr) {
+    error = "Failed to resolve '" + host + "': getaddrinfo error " + std::to_string(gai_rc);
+    return false;
+  }
+
+  SOCKET sock = INVALID_SOCKET;
+  int last_wsa_error = 0;
+  for (const struct addrinfo* addr = resolved; addr != nullptr; addr = addr->ai_next) {
+    sock = socket(addr->ai_family, addr->ai_socktype, addr->ai_protocol);
+    if (sock == INVALID_SOCKET) {
+      last_wsa_error = WSAGetLastError();
+      continue;
     }
-#ifdef _MSC_VER
-  } __except (EXCEPTION_EXECUTE_HANDLER) {
-    matched = false;
-  }
-#endif
-  return matched;
-}
-
-void* GetNodeBaseObjectWrapper(v8::Local<v8::Object> object) {
-#if V8_MAJOR_VERSION >= 14
-  return object->GetAlignedPointerFromInternalField(1, v8::kEmbedderDataTypeTagDefault);
-#else
-  return object->GetAlignedPointerFromInternalField(1);
-#endif
-}
-
-bool ExtractTcpFdFromNodeHandle(const Napi::Value& value, int& fd, std::string& error) {
-  if (!value.IsObject()) {
-    error = "Expected Node TCP handle object";
-    return false;
-  }
-
-  v8::Local<v8::Value> v8_value = ToV8Local(value);
-  if (!v8_value->IsObject()) {
-    error = "Expected V8 object for Node TCP handle";
-    return false;
-  }
-
-  v8::Local<v8::Object> handle_obj = v8_value.As<v8::Object>();
-  if (handle_obj->InternalFieldCount() <= 1) {
-    error = "Node TCP handle has no internal fields";
-    return false;
-  }
-
-  // Node BaseObject stores an embedder tag in field 0 and the C++ wrapper in
-  // BaseObject::kSlot (field 1). TCPWrap is private, so avoid including Node
-  // internals and only use this stable internal-field convention.
-  void* wrapper = GetNodeBaseObjectWrapper(handle_obj);
-  if (wrapper == nullptr) {
-    error = "Node TCP handle internal wrapper is null";
-    return false;
-  }
-
-  uv_tcp_t* tcp = nullptr;
-  // TCPWrap is private Node internals. Look for the embedded uv_tcp_t by
-  // scanning the wrapper object for a uv_handle_t whose data points back to it.
-  for (size_t offset = 0; offset < 2048; offset += sizeof(void*)) {
-    if (TryReadUvHandle(wrapper, offset, &tcp)) {
+    if (connect(sock, addr->ai_addr, static_cast<int>(addr->ai_addrlen)) == 0) {
       break;
     }
+    last_wsa_error = WSAGetLastError();
+    closesocket(sock);
+    sock = INVALID_SOCKET;
   }
-  if (tcp == nullptr) {
-    error = "Failed to locate uv_tcp_t in Node TCP handle";
+  freeaddrinfo(resolved);
+
+  if (sock == INVALID_SOCKET) {
+    error = "Failed to connect to " + host + ":" + port_str + " (WSA error " +
+            std::to_string(last_wsa_error) + ")";
     return false;
   }
 
-  uv_os_fd_t os_fd{};
-  const int rc = uv_fileno(reinterpret_cast<const uv_handle_t*>(tcp), &os_fd);
-  if (rc != 0) {
-    error = std::string("uv_fileno failed: ") + uv_strerror(rc);
-    return false;
-  }
+  // Handshake frames are small; don't let Nagle delay them (best effort).
+  const BOOL no_delay = TRUE;
+  setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, reinterpret_cast<const char*>(&no_delay),
+             sizeof(no_delay));
 
-  const uintptr_t raw_fd = reinterpret_cast<uintptr_t>(os_fd);
+  const uintptr_t raw_fd = static_cast<uintptr_t>(sock);
   if (raw_fd > static_cast<uintptr_t>(std::numeric_limits<int>::max())) {
-    error = "Extracted TCP socket handle is too large for OpenSSL fd API";
+    closesocket(sock);
+    error = "Connected socket handle is too large for OpenSSL fd API";
     return false;
   }
 
   fd = static_cast<int>(raw_fd);
-  if (fd < 0) {
-    error = "Extracted TCP socket handle is invalid";
-    return false;
-  }
   return true;
 }
 #endif
@@ -852,6 +828,154 @@ void TunnelForwarder::DeviceToTunLoop() {
 
 // --- N-API wrapper ---
 
+namespace {
+
+// The connect and CDTunnel-handshake phases block on socket I/O (SSL_connect
+// and friends run with a 15s deadline). On Windows the transport is a local
+// loopback bridge pumped by JS streams (see forwarder.ts bridgeToNative), so
+// these phases MUST run off the JS thread -- if they blocked the event loop,
+// the bridge could never deliver their bytes and every connect would time
+// out. Each worker holds a persistent reference to the wrap object so the
+// underlying TunnelForwarder outlives the async work.
+
+#ifdef _WIN32
+class ConnectHostWorker : public Napi::AsyncWorker {
+public:
+  ConnectHostWorker(Napi::Object receiver,
+                    TunnelForwarder& forwarder,
+                    std::string host,
+                    uint16_t port,
+                    std::string cert_pem,
+                    std::string key_pem,
+                    Napi::Promise::Deferred deferred)
+      : Napi::AsyncWorker(receiver.Env()),
+        receiver_(Napi::Persistent(receiver)),
+        forwarder_(forwarder),
+        host_(std::move(host)),
+        port_(port),
+        cert_pem_(std::move(cert_pem)),
+        key_pem_(std::move(key_pem)),
+        deferred_(deferred) {}
+
+  void Execute() override {
+    std::string error;
+    int fd = -1;
+    if (!ConnectRawTcp(host_, port_, fd, error)) {
+      SetError(error);
+      return;
+    }
+    const bool ok = forwarder_.Connect(fd, cert_pem_, key_pem_, error);
+    // TunnelSslClient duplicates the fd (WSADuplicateSocketW) and owns the
+    // duplicate, so the original is ours to close either way.
+    closesocket(static_cast<SOCKET>(fd));
+    if (!ok) {
+      SetError(error);
+    }
+  }
+
+  void OnOK() override { deferred_.Resolve(Env().Undefined()); }
+  void OnError(const Napi::Error& e) override { deferred_.Reject(e.Value()); }
+
+private:
+  Napi::ObjectReference receiver_;
+  TunnelForwarder& forwarder_;
+  std::string host_;
+  uint16_t port_;
+  std::string cert_pem_;
+  std::string key_pem_;
+  Napi::Promise::Deferred deferred_;
+};
+
+class ConnectPskHostWorker : public Napi::AsyncWorker {
+public:
+  ConnectPskHostWorker(Napi::Object receiver,
+                       TunnelForwarder& forwarder,
+                       std::string host,
+                       uint16_t port,
+                       std::vector<uint8_t> psk,
+                       std::string identity,
+                       Napi::Promise::Deferred deferred)
+      : Napi::AsyncWorker(receiver.Env()),
+        receiver_(Napi::Persistent(receiver)),
+        forwarder_(forwarder),
+        host_(std::move(host)),
+        port_(port),
+        psk_(std::move(psk)),
+        identity_(std::move(identity)),
+        deferred_(deferred) {}
+
+  void Execute() override {
+    std::string error;
+    int fd = -1;
+    if (!ConnectRawTcp(host_, port_, fd, error)) {
+      SetError(error);
+      return;
+    }
+    const bool ok = forwarder_.ConnectPsk(fd, psk_.data(), psk_.size(), identity_, error);
+    closesocket(static_cast<SOCKET>(fd));
+    if (!ok) {
+      SetError(error);
+    }
+  }
+
+  void OnOK() override { deferred_.Resolve(Env().Undefined()); }
+  void OnError(const Napi::Error& e) override { deferred_.Reject(e.Value()); }
+
+private:
+  Napi::ObjectReference receiver_;
+  TunnelForwarder& forwarder_;
+  std::string host_;
+  uint16_t port_;
+  std::vector<uint8_t> psk_;
+  std::string identity_;
+  Napi::Promise::Deferred deferred_;
+};
+#endif  // _WIN32
+
+class HandshakeWorker : public Napi::AsyncWorker {
+public:
+  HandshakeWorker(Napi::Object receiver,
+                  TunnelForwarder& forwarder,
+                  uint32_t requested_mtu,
+                  Napi::Promise::Deferred deferred)
+      : Napi::AsyncWorker(receiver.Env()),
+        receiver_(Napi::Persistent(receiver)),
+        forwarder_(forwarder),
+        requested_mtu_(requested_mtu),
+        deferred_(deferred) {}
+
+  void Execute() override {
+    std::string error;
+    if (!forwarder_.Handshake(requested_mtu_, handshake_, error)) {
+      SetError(error);
+    }
+  }
+
+  void OnOK() override {
+    Napi::Env env = Env();
+    Napi::Object client_params = Napi::Object::New(env);
+    client_params.Set("address", handshake_.client_address);
+    client_params.Set("mtu", handshake_.mtu);
+
+    Napi::Object result = Napi::Object::New(env);
+    result.Set("clientParameters", client_params);
+    result.Set("serverAddress", handshake_.server_address);
+    result.Set("serverRSDPort", handshake_.server_rsd_port);
+    deferred_.Resolve(result);
+  }
+
+  void OnError(const Napi::Error& e) override { deferred_.Reject(e.Value()); }
+
+private:
+  Napi::ObjectReference receiver_;
+  TunnelForwarder& forwarder_;
+  uint32_t requested_mtu_;
+  TunnelHandshakeInfo handshake_{};
+  Napi::Promise::Deferred deferred_;
+};
+
+}  // namespace
+
 class TunnelForwarderWrap : public Napi::ObjectWrap<TunnelForwarderWrap> {
 public:
   static Napi::Object Init(Napi::Env env, Napi::Object exports) {
@@ -859,9 +983,9 @@ public:
         DefineClass(env,
                     "TunnelForwarder",
                     {InstanceMethod("connect", &TunnelForwarderWrap::Connect),
-                     InstanceMethod("connectSocket", &TunnelForwarderWrap::ConnectSocket),
+                     InstanceMethod("connectHost", &TunnelForwarderWrap::ConnectHost),
                      InstanceMethod("connectPsk", &TunnelForwarderWrap::ConnectPsk),
-                     InstanceMethod("connectPskSocket", &TunnelForwarderWrap::ConnectPskSocket),
+                     InstanceMethod("connectPskHost", &TunnelForwarderWrap::ConnectPskHost),
                      InstanceMethod("handshake", &TunnelForwarderWrap::Handshake),
                      InstanceMethod("startForwarding", &TunnelForwarderWrap::StartForwarding),
                      InstanceMethod("stop", &TunnelForwarderWrap::Stop)});
@@ -921,28 +1045,31 @@ private:
     return env.Undefined();
   }
 
-  Napi::Value ConnectSocket(const Napi::CallbackInfo& info) {
+  Napi::Value ConnectHost(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
-    if (info.Length() < 3 || !info[1].IsString() || !info[2].IsString()) {
-      Napi::TypeError::New(env, "Expected (tcpHandle, certPem, keyPem)")
+    if (info.Length() < 4 || !info[0].IsString() || !info[1].IsNumber() || !info[2].IsString() ||
+        !info[3].IsString()) {
+      Napi::TypeError::New(env, "Expected (host, port, certPem, keyPem)")
           .ThrowAsJavaScriptException();
       return env.Undefined();
     }
 
 #ifdef _WIN32
-    int tcp_fd = -1;
-    std::string error;
-    if (!ExtractTcpFdFromNodeHandle(info[0], tcp_fd, error) ||
-        !forwarder_.Connect(tcp_fd,
-                            info[1].As<Napi::String>().Utf8Value(),
-                            info[2].As<Napi::String>().Utf8Value(),
-                            error)) {
-      Napi::Error::New(env, error).ThrowAsJavaScriptException();
-    }
+    auto deferred = Napi::Promise::Deferred::New(env);
+    auto* worker =
+        new ConnectHostWorker(info.This().As<Napi::Object>(),
+                              forwarder_,
+                              info[0].As<Napi::String>().Utf8Value(),
+                              static_cast<uint16_t>(info[1].As<Napi::Number>().Uint32Value()),
+                              info[2].As<Napi::String>().Utf8Value(),
+                              info[3].As<Napi::String>().Utf8Value(),
+                              deferred);
+    worker->Queue();
+    return deferred.Promise();
 #else
-    Napi::Error::New(env, "connectSocket is only supported on Windows").ThrowAsJavaScriptException();
-#endif
+    Napi::Error::New(env, "connectHost is only supported on Windows").ThrowAsJavaScriptException();
     return env.Undefined();
+#endif
   }
 
   Napi::Value ConnectPsk(const Napi::CallbackInfo& info) {
@@ -970,31 +1097,39 @@ private:
     return env.Undefined();
   }
 
-  Napi::Value ConnectPskSocket(const Napi::CallbackInfo& info) {
+  Napi::Value ConnectPskHost(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
-    if (info.Length() < 2 || !info[1].IsBuffer()) {
-      Napi::TypeError::New(env, "Expected (tcpHandle, pskBuffer[, identity])")
+    if (info.Length() < 3 || !info[0].IsString() || !info[1].IsNumber() || !info[2].IsBuffer()) {
+      Napi::TypeError::New(env, "Expected (host, port, pskBuffer[, identity])")
           .ThrowAsJavaScriptException();
       return env.Undefined();
     }
 
     std::string identity;
-    if (info.Length() >= 3 && info[2].IsString()) {
-      identity = info[2].As<Napi::String>().Utf8Value();
+    if (info.Length() >= 4 && info[3].IsString()) {
+      identity = info[3].As<Napi::String>().Utf8Value();
     }
 
 #ifdef _WIN32
-    int tcp_fd = -1;
-    std::string error;
-    Napi::Buffer<uint8_t> psk = info[1].As<Napi::Buffer<uint8_t>>();
-    if (!ExtractTcpFdFromNodeHandle(info[0], tcp_fd, error) ||
-        !forwarder_.ConnectPsk(tcp_fd, psk.Data(), psk.Length(), identity, error)) {
-      Napi::Error::New(env, error).ThrowAsJavaScriptException();
-    }
+    // Copy the PSK on the JS thread; the buffer may be collected before the
+    // worker runs.
+    Napi::Buffer<uint8_t> psk = info[2].As<Napi::Buffer<uint8_t>>();
+    std::vector<uint8_t> psk_copy(psk.Data(), psk.Data() + psk.Length());
+    auto deferred = Napi::Promise::Deferred::New(env);
+    auto* worker =
+        new ConnectPskHostWorker(info.This().As<Napi::Object>(),
+                                 forwarder_,
+                                 info[0].As<Napi::String>().Utf8Value(),
+                                 static_cast<uint16_t>(info[1].As<Napi::Number>().Uint32Value()),
+                                 std::move(psk_copy),
+                                 std::move(identity),
+                                 deferred);
+    worker->Queue();
+    return deferred.Promise();
 #else
-    Napi::Error::New(env, "connectPskSocket is only supported on Windows").ThrowAsJavaScriptException();
-#endif
+    Napi::Error::New(env, "connectPskHost is only supported on Windows").ThrowAsJavaScriptException();
     return env.Undefined();
+#endif
   }
 
   Napi::Value Handshake(const Napi::CallbackInfo& info) {
@@ -1004,22 +1139,15 @@ private:
       return env.Undefined();
     }
 
-    TunnelHandshakeInfo handshake{};
-    std::string error;
-    if (!forwarder_.Handshake(info[0].As<Napi::Number>().Uint32Value(), handshake, error)) {
-      Napi::Error::New(env, error).ThrowAsJavaScriptException();
-      return env.Undefined();
-    }
-
-    Napi::Object client_params = Napi::Object::New(env);
-    client_params.Set("address", handshake.client_address);
-    client_params.Set("mtu", handshake.mtu);
-
-    Napi::Object result = Napi::Object::New(env);
-    result.Set("clientParameters", client_params);
-    result.Set("serverAddress", handshake.server_address);
-    result.Set("serverRSDPort", handshake.server_rsd_port);
-    return result;
+    // Async on every platform: the CDTunnel exchange blocks on socket I/O,
+    // and on Windows that I/O flows through the JS-pumped loopback bridge.
+    auto deferred = Napi::Promise::Deferred::New(env);
+    auto* worker = new HandshakeWorker(info.This().As<Napi::Object>(),
+                                       forwarder_,
+                                       info[0].As<Napi::Number>().Uint32Value(),
+                                       deferred);
+    worker->Queue();
+    return deferred.Promise();
   }
 
   Napi::Value StartForwarding(const Napi::CallbackInfo& info) {

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -38,23 +38,11 @@ using Clock = std::chrono::steady_clock;
 using TimePoint = Clock::time_point;
 
 #ifdef _WIN32
-// Opens a plain TCP connection directly via WinSock, given a host/port.
-//
-// This exists so Windows callers never need to hand a JS net.Socket to the
-// native addon and have it try to recover the underlying OS socket. That
-// used to be done by reading V8's private internal-object layout to find
-// the embedded uv_tcp_t (net.Socket's own `_handle.fd` is hard-coded to -1
-// on Windows, unlike POSIX, because libuv wraps an opaque SOCKET there
-// rather than a POSIX fd) -- but V8's internal-field/pointer-tagging
-// layout is undocumented and not ABI-stable across V8 versions, so a
-// prebuild compiled against one Node/V8 build could fail to resolve the
-// symbols it needs on another (observed as an unhandled delay-load
-// ERROR_PROC_NOT_FOUND crash, exit code 0xC06D007F).
-//
-// Instead, the JS layer bridges its already-negotiated socket through a
-// local loopback listener (see forwarder.ts bridgeToNative) and passes that
-// listener's (host, port) here; this dials it with plain WinSock, so no
-// Node/V8 internals are involved at all.
+// Dials a host/port with plain WinSock. Windows can't recover the OS socket
+// from a JS net.Socket (`_handle.fd` is -1; reading V8 internals to find it
+// is not ABI-stable and broke a prebuild across a Node upgrade), so the JS
+// layer instead bridges its socket through a loopback listener and passes
+// that address here. See forwarder.ts bridgeToNative.
 bool ConnectRawTcp(const std::string& host, uint16_t port, int& fd, std::string& error) {
   struct addrinfo hints {};
   hints.ai_family = AF_UNSPEC;
@@ -830,13 +818,10 @@ void TunnelForwarder::DeviceToTunLoop() {
 
 namespace {
 
-// The connect and CDTunnel-handshake phases block on socket I/O (SSL_connect
-// and friends run with a 15s deadline). On Windows the transport is a local
-// loopback bridge pumped by JS streams (see forwarder.ts bridgeToNative), so
-// these phases MUST run off the JS thread -- if they blocked the event loop,
-// the bridge could never deliver their bytes and every connect would time
-// out. Each worker holds a persistent reference to the wrap object so the
-// underlying TunnelForwarder outlives the async work.
+// Connect and handshake block on socket I/O, so they must run off the JS
+// thread: on Windows their bytes flow through the JS-pumped loopback bridge,
+// which a blocked event loop could never deliver. Each worker keeps a
+// persistent ref to the wrap so the forwarder outlives the async work.
 
 #ifdef _WIN32
 class ConnectHostWorker : public Napi::AsyncWorker {

--- a/src/native/win_delay_load_failure_hook.cc
+++ b/src/native/win_delay_load_failure_hook.cc
@@ -1,20 +1,8 @@
-// MSVC's delay-load runtime (delayimp.h) raises an unhandled structured
-// exception -- VcppException(ERROR_SEVERITY_ERROR, ERROR_MOD_NOT_FOUND /
-// ERROR_PROC_NOT_FOUND), surfacing as process exit code 0xC06D007E /
-// 0xC06D007F -- when a delay-loaded DLL, or a specific exported function
-// inside it, can't be resolved at first use. Because this happens via SEH
-// rather than a C++ exception or a Node-API error, it terminates the whole
-// process silently: Node's own uncaughtException/unhandledRejection
-// handlers never see it, and nothing is written to stdout/stderr by
-// default.
-//
-// This installs a delay-load *failure* hook (distinct from node-gyp's own
-// __pfnDliNotifyHook2 in win_delay_load_hook.cc, which only redirects the
-// load target for the host executable) so that if this ever happens again
-// -- for example a published prebuild resolving a node.exe export that
-// isn't present on the Node.js build it's actually run against -- the
-// failure is reported with the exact DLL/symbol name before the process
-// dies, instead of surfacing only as an opaque exit code.
+// An unresolvable delay-loaded DLL or export kills the process via SEH (exit
+// code 0xC06D007E/F) before any JS handler sees it, with nothing logged. This
+// failure hook prints the offending DLL/symbol first, turning an opaque exit
+// code into a diagnosable one. Distinct from node-gyp's __pfnDliNotifyHook2
+// in win_delay_load_hook.cc, which only redirects the load target.
 
 #ifdef _MSC_VER
 
@@ -55,10 +43,7 @@ FARPROC WINAPI DelayLoadFailureHook(unsigned int event, DelayLoadInfo* info) {
     default:
       break;
   }
-  // Returning NULL preserves the default behavior -- the delay-load runtime
-  // still raises its structured exception afterward. This hook only adds a
-  // diagnostic message before that happens; it doesn't change outcomes on
-  // machines where resolution succeeds.
+  // NULL keeps the default behavior: the runtime still raises afterward.
   return NULL;
 }
 

--- a/src/native/win_delay_load_failure_hook.cc
+++ b/src/native/win_delay_load_failure_hook.cc
@@ -1,0 +1,71 @@
+// MSVC's delay-load runtime (delayimp.h) raises an unhandled structured
+// exception -- VcppException(ERROR_SEVERITY_ERROR, ERROR_MOD_NOT_FOUND /
+// ERROR_PROC_NOT_FOUND), surfacing as process exit code 0xC06D007E /
+// 0xC06D007F -- when a delay-loaded DLL, or a specific exported function
+// inside it, can't be resolved at first use. Because this happens via SEH
+// rather than a C++ exception or a Node-API error, it terminates the whole
+// process silently: Node's own uncaughtException/unhandledRejection
+// handlers never see it, and nothing is written to stdout/stderr by
+// default.
+//
+// This installs a delay-load *failure* hook (distinct from node-gyp's own
+// __pfnDliNotifyHook2 in win_delay_load_hook.cc, which only redirects the
+// load target for the host executable) so that if this ever happens again
+// -- for example a published prebuild resolving a node.exe export that
+// isn't present on the Node.js build it's actually run against -- the
+// failure is reported with the exact DLL/symbol name before the process
+// dies, instead of surfacing only as an opaque exit code.
+
+#ifdef _MSC_VER
+
+#pragma managed(push, off)
+
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+
+#include <windows.h>
+
+#include <cstdio>
+#include <delayimp.h>
+
+namespace {
+
+FARPROC WINAPI DelayLoadFailureHook(unsigned int event, DelayLoadInfo* info) {
+  switch (event) {
+    case dliFailLoadLib:
+      std::fprintf(
+          stderr,
+          "[tuntap] Failed to delay-load '%s' (Win32 error %lu). This native "
+          "addon build may be incompatible with the current Node.js "
+          "install; try reinstalling appium-ios-tuntap or building it from "
+          "source (npm install --build-from-source).\n",
+          info->szDll, info->dwLastError);
+      break;
+    case dliFailGetProc:
+      std::fprintf(
+          stderr,
+          "[tuntap] Failed to resolve '%s' in '%s' (Win32 error %lu). This "
+          "native addon build may be incompatible with the current Node.js "
+          "install; try reinstalling appium-ios-tuntap or building it from "
+          "source (npm install --build-from-source).\n",
+          info->dlp.fImportByName ? info->dlp.szProcName : "(ordinal import)",
+          info->szDll, info->dwLastError);
+      break;
+    default:
+      break;
+  }
+  // Returning NULL preserves the default behavior -- the delay-load runtime
+  // still raises its structured exception afterward. This hook only adds a
+  // diagnostic message before that happens; it doesn't change outcomes on
+  // machines where resolution succeeds.
+  return NULL;
+}
+
+}  // namespace
+
+decltype(__pfnDliFailureHook2) __pfnDliFailureHook2 = DelayLoadFailureHook;
+
+#pragma managed(pop)
+
+#endif  // _MSC_VER

--- a/src/tunnel/forwarder.ts
+++ b/src/tunnel/forwarder.ts
@@ -1,6 +1,6 @@
+import {createRequire} from 'node:module';
 import {createServer} from 'node:net';
 import type {Server, Socket} from 'node:net';
-import {createRequire} from 'node:module';
 
 import {getPkgRoot} from '../pkg-root.js';
 import type {TunTap} from '../TunTap.js';

--- a/src/tunnel/forwarder.ts
+++ b/src/tunnel/forwarder.ts
@@ -112,28 +112,23 @@ export class TunnelForwarder {
   }
 
   /**
-   * Windows has no stable way for native code to recover the OS socket from
-   * an already-connected net.Socket: `_handle.fd` is hard-coded to -1 there
-   * (libuv wraps an opaque SOCKET, not a POSIX fd), and reading V8's private
-   * internal-object layout to find it isn't ABI-stable across V8 versions
-   * (it broke a published build across a single Node upgrade).
+   * Bridges an already-connected `tcpSocket` to native code through a local
+   * loopback TCP pair, so native dials the bridge instead of touching the
+   * original socket.
    *
-   * `tcpSocket` also can't simply be redialed by address: on Windows it's
-   * typically the product of a one-time, stateful usbmux handshake (send a
-   * "Connect" message, get an OK, then the *same* socket is repurposed in
-   * place) rather than a plain listener that accepts fresh connections --
-   * dialing its remoteAddress/remotePort again just opens a brand new,
-   * unnegotiated session.
+   * Windows can't hand the OS socket to native (`_handle.fd` is -1, and
+   * reading V8 internals to find it broke a prebuild across a Node upgrade),
+   * and the socket can't be redialed either -- it's the product of a
+   * one-time usbmux handshake, so a fresh dial gets an unnegotiated session.
    *
-   * So instead of extracting or redialing anything, bridge the already-
-   * working `tcpSocket` through a local loopback TCP pair: pipe it into one
-   * end, and let native code dial the other end itself via plain WinSock.
-   * No Node/V8 internals are touched, and the already-negotiated session is
-   * left completely alone.
+   * Costs roughly half the throughput of a direct fd handoff, since every
+   * byte crosses two extra user/kernel boundaries with the JS event loop as
+   * the pump. Accepted deliberately: slower but stable.
    *
-   * Because these pipes are pumped by the JS event loop, the native
-   * connect/handshake calls that read through the bridge run on async
-   * workers (promises), never synchronously on the JS thread.
+   * Only a real device exercises this. To verify changes, link into
+   * appium-ios-remotexpc and run `test:afc-tunnel-stability` with
+   * AFC_STABILITY_ITERATIONS=20; what matters is flatness, not absolute
+   * speed -- degrading later rounds mean the bridge isn't draining.
    */
   private bridgeToNative(tcpSocket: Socket): Promise<{host: string; port: number}> {
     return new Promise((resolve, reject) => {
@@ -142,6 +137,9 @@ export class TunnelForwarder {
         // listening as soon as it arrives so the ephemeral port closes.
         server.close(() => {});
         localSocket.setNoDelay(true);
+        // Mirrors the device socket's settings; on loopback this is mostly
+        // defensive, since a dead peer already surfaces as close/error.
+        localSocket.setKeepAlive(true, 1000);
         tcpSocket.pipe(localSocket);
         localSocket.pipe(tcpSocket);
 

--- a/src/tunnel/forwarder.ts
+++ b/src/tunnel/forwarder.ts
@@ -1,5 +1,6 @@
+import {createServer} from 'node:net';
+import type {Server, Socket} from 'node:net';
 import {createRequire} from 'node:module';
-import type {Socket} from 'node:net';
 
 import {getPkgRoot} from '../pkg-root.js';
 import type {TunTap} from '../TunTap.js';
@@ -22,10 +23,10 @@ export interface TunnelPskTlsCredentials {
 
 interface NativeTunnelForwarder {
   connect(tcpFd: number, certPem: string, keyPem: string): void;
-  connectSocket(tcpHandle: unknown, certPem: string, keyPem: string): void;
+  connectHost(host: string, port: number, certPem: string, keyPem: string): Promise<void>;
   connectPsk(tcpFd: number, psk: Buffer, identity?: string): void;
-  connectPskSocket(tcpHandle: unknown, psk: Buffer, identity?: string): void;
-  handshake(requestedMtu: number): TunnelInfo;
+  connectPskHost(host: string, port: number, psk: Buffer, identity?: string): Promise<void>;
+  handshake(requestedMtu: number): Promise<TunnelInfo>;
   startForwarding(tunForwardingHandle: unknown, onError?: (message: string) => void): void;
   stop(): void;
 }
@@ -40,42 +41,43 @@ interface NativeTuntapModule {
 export class TunnelForwarder {
   private forwarder: NativeTunnelForwarder | null = null;
   private retainedSocket: Socket | null = null;
+  private loopbackBridge: Server | null = null;
 
-  connect(tcpSocket: Socket, credentials: TunnelLockdownTlsCredentials): void {
-    tcpSocket.pause();
-    tcpSocket.removeAllListeners();
-
+  async connect(tcpSocket: Socket, credentials: TunnelLockdownTlsCredentials): Promise<void> {
     const native = require('node-gyp-build')(getPkgRoot()) as NativeTuntapModule;
     this.forwarder = new native.TunnelForwarder();
+
     if (process.platform === 'win32') {
-      this.forwarder.connectSocket(getSocketHandle(tcpSocket), credentials.cert, credentials.key);
+      const {host, port} = await this.bridgeToNative(tcpSocket);
+      await this.forwarder.connectHost(host, port, credentials.cert, credentials.key);
     } else {
+      tcpSocket.pause();
+      tcpSocket.removeAllListeners();
       this.forwarder.connect(getSocketFd(tcpSocket), credentials.cert, credentials.key);
+      this.takeSocketOwnership(tcpSocket);
     }
-
-    this.takeSocketOwnership(tcpSocket);
   }
 
-  connectPsk(tcpSocket: Socket, credentials: TunnelPskTlsCredentials): void {
-    tcpSocket.pause();
-    tcpSocket.removeAllListeners();
-
+  async connectPsk(tcpSocket: Socket, credentials: TunnelPskTlsCredentials): Promise<void> {
     const native = require('node-gyp-build')(getPkgRoot()) as NativeTuntapModule;
     this.forwarder = new native.TunnelForwarder();
-    if (process.platform === 'win32') {
-      this.forwarder.connectPskSocket(getSocketHandle(tcpSocket), credentials.psk, credentials.identity ?? '');
-    } else {
-      this.forwarder.connectPsk(getSocketFd(tcpSocket), credentials.psk, credentials.identity ?? '');
-    }
 
-    this.takeSocketOwnership(tcpSocket);
+    if (process.platform === 'win32') {
+      const {host, port} = await this.bridgeToNative(tcpSocket);
+      await this.forwarder.connectPskHost(host, port, credentials.psk, credentials.identity ?? '');
+    } else {
+      tcpSocket.pause();
+      tcpSocket.removeAllListeners();
+      this.forwarder.connectPsk(getSocketFd(tcpSocket), credentials.psk, credentials.identity ?? '');
+      this.takeSocketOwnership(tcpSocket);
+    }
   }
 
-  handshake(requestedMtu: number): TunnelInfo {
+  async handshake(requestedMtu: number): Promise<TunnelInfo> {
     if (!this.forwarder) {
       throw new Error('Tunnel forwarder is not connected');
     }
-    return this.forwarder.handshake(requestedMtu);
+    return await this.forwarder.handshake(requestedMtu);
   }
 
   startForwarding(tun: TunTap, onError?: (message: string) => void): void {
@@ -93,6 +95,12 @@ export class TunnelForwarder {
   stop(): void {
     this.forwarder?.stop();
     this.forwarder = null;
+    if (this.loopbackBridge) {
+      // May already be closed (the listener shuts down after the first
+      // accept); the callback form swallows ERR_SERVER_NOT_RUNNING.
+      this.loopbackBridge.close(() => {});
+      this.loopbackBridge = null;
+    }
     if (this.retainedSocket) {
       destroySocket(this.retainedSocket);
       this.retainedSocket = null;
@@ -102,6 +110,63 @@ export class TunnelForwarder {
   private takeSocketOwnership(socket: Socket): void {
     destroySocket(socket);
   }
+
+  /**
+   * Windows has no stable way for native code to recover the OS socket from
+   * an already-connected net.Socket: `_handle.fd` is hard-coded to -1 there
+   * (libuv wraps an opaque SOCKET, not a POSIX fd), and reading V8's private
+   * internal-object layout to find it isn't ABI-stable across V8 versions
+   * (it broke a published build across a single Node upgrade).
+   *
+   * `tcpSocket` also can't simply be redialed by address: on Windows it's
+   * typically the product of a one-time, stateful usbmux handshake (send a
+   * "Connect" message, get an OK, then the *same* socket is repurposed in
+   * place) rather than a plain listener that accepts fresh connections --
+   * dialing its remoteAddress/remotePort again just opens a brand new,
+   * unnegotiated session.
+   *
+   * So instead of extracting or redialing anything, bridge the already-
+   * working `tcpSocket` through a local loopback TCP pair: pipe it into one
+   * end, and let native code dial the other end itself via plain WinSock.
+   * No Node/V8 internals are touched, and the already-negotiated session is
+   * left completely alone.
+   *
+   * Because these pipes are pumped by the JS event loop, the native
+   * connect/handshake calls that read through the bridge run on async
+   * workers (promises), never synchronously on the JS thread.
+   */
+  private bridgeToNative(tcpSocket: Socket): Promise<{host: string; port: number}> {
+    return new Promise((resolve, reject) => {
+      const server = createServer((localSocket) => {
+        // Only one bridge client (the native forwarder) is expected; stop
+        // listening as soon as it arrives so the ephemeral port closes.
+        server.close(() => {});
+        localSocket.setNoDelay(true);
+        tcpSocket.pipe(localSocket);
+        localSocket.pipe(tcpSocket);
+
+        const teardown = () => {
+          destroySocket(localSocket);
+          destroySocket(tcpSocket);
+        };
+        localSocket.on('error', teardown);
+        localSocket.on('close', teardown);
+        tcpSocket.on('error', teardown);
+      });
+
+      server.once('error', reject);
+      server.listen(0, '127.0.0.1', () => {
+        const address = server.address();
+        if (!address || typeof address !== 'object') {
+          reject(new Error('Failed to determine loopback bridge port'));
+          return;
+        }
+        this.loopbackBridge = server;
+        this.retainedSocket = tcpSocket;
+        resolve({host: '127.0.0.1', port: address.port});
+      });
+    });
+  }
 }
 
 function getSocketFd(socket: Socket): number {
@@ -110,14 +175,6 @@ function getSocketFd(socket: Socket): number {
     return handle.fd;
   }
   throw new Error('TCP socket file descriptor is not available');
-}
-
-function getSocketHandle(socket: Socket): unknown {
-  const handle = (socket as {_handle?: unknown})._handle;
-  if (handle) {
-    return handle;
-  }
-  throw new Error('TCP socket handle is not available');
 }
 
 function destroySocket(socket: Socket): void {

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -141,11 +141,7 @@ export async function connectToTunnelLockdown(
   credentials: TunnelLockdownTlsCredentials,
   options?: {onDead?: (reason: string) => void},
 ): Promise<TunnelConnection> {
-  return connectTunnel(
-    tcpSocket,
-    (forwarder) => forwarder.connect(tcpSocket, credentials),
-    options?.onDead,
-  );
+  return connectTunnel(tcpSocket, (forwarder) => forwarder.connect(tcpSocket, credentials), options?.onDead);
 }
 
 /**
@@ -158,11 +154,7 @@ export async function connectToTunnelPsk(
   credentials: TunnelPskTlsCredentials,
   options?: {onDead?: (reason: string) => void},
 ): Promise<TunnelConnection> {
-  return connectTunnel(
-    tcpSocket,
-    (forwarder) => forwarder.connectPsk(tcpSocket, credentials),
-    options?.onDead,
-  );
+  return connectTunnel(tcpSocket, (forwarder) => forwarder.connectPsk(tcpSocket, credentials), options?.onDead);
 }
 
 async function connectTunnel(

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -143,9 +143,7 @@ export async function connectToTunnelLockdown(
 ): Promise<TunnelConnection> {
   return connectTunnel(
     tcpSocket,
-    (forwarder) => {
-      forwarder.connect(tcpSocket, credentials);
-    },
+    (forwarder) => forwarder.connect(tcpSocket, credentials),
     options?.onDead,
   );
 }
@@ -162,16 +160,14 @@ export async function connectToTunnelPsk(
 ): Promise<TunnelConnection> {
   return connectTunnel(
     tcpSocket,
-    (forwarder) => {
-      forwarder.connectPsk(tcpSocket, credentials);
-    },
+    (forwarder) => forwarder.connectPsk(tcpSocket, credentials),
     options?.onDead,
   );
 }
 
 async function connectTunnel(
   tcpSocket: Socket,
-  setupTls: (forwarder: TunnelForwarder) => void,
+  setupTls: (forwarder: TunnelForwarder) => Promise<void>,
   onDead?: (reason: string) => void,
 ): Promise<TunnelConnection> {
   const tunnelManager = new TunnelManager();
@@ -181,8 +177,8 @@ async function connectTunnel(
     tcpSocket.setNoDelay(true);
     tcpSocket.setKeepAlive(true, 1000);
 
-    setupTls(forwarder);
-    const tunnelInfo = forwarder.handshake(CD_TUNNEL_MTU);
+    await setupTls(forwarder);
+    const tunnelInfo = await forwarder.handshake(CD_TUNNEL_MTU);
     tunDebug('Tunnel parameters exchanged:', tunnelInfo);
 
     const tunInterfaceInfo = await tunnelManager.setupInterface(tunnelInfo);


### PR DESCRIPTION
## Problem

On Windows, establishing a tunnel with the published `win32-x64` prebuild kills the Node.js process **silently** partway through `TunnelManager.getTunnel()`. No JS error is thrown, no `uncaughtException`/`unhandledRejection` fires, and nothing is printed — the process just exits mid-flow with exit code `-1066598273` (`0xC06D007F`).

Observed with `appium-ios-tuntap@1.2.2` on Windows 11 + Node.js v24.15.0, driving tunnel creation through `appium-ios-remotexpc` against a physical iPhone (USB, paired/trusted).

```
info TunnelCreation CoreDeviceProxy started successfully
info TunnelCreation Creating tunnel...
<process exits — nothing else is ever printed>
```

## Root cause

`0xC06D007F` is `VcppException(ERROR_SEVERITY_ERROR, ERROR_PROC_NOT_FOUND)` — the MSVC delay-load runtime's structured exception for "a delay-loaded module was found, but a required export inside it wasn't". It's raised via SEH, not as a JS or C++ exception, so no JS-level handler can observe it.

`dumpbin /IMPORTS` on the published prebuild shows the culprit imports in its `node.exe` delay-load table:

```
?ToExternalPointerTag@v8@@YA?AW4ExternalPointerTag@internal@1@G@Z
?SlowGetAlignedPointerFromInternalField@Object@v8@@AEAAPEAXHG@Z
```

Neither resolves against Node v24.15.0's `node.exe`:

- `ToExternalPointerTag` is not exported at all;
- `SlowGetAlignedPointerFromInternalField` is exported only with the **un-tagged** signature (`...AEAAPEAXH@Z`), not the tagged one (`...AEAAPEAXHG@Z`) the prebuild was compiled against.

These come from `ExtractTcpFdFromNodeHandle()` in `src/native/tunnel_forwarder.cc`, which recovered the raw `SOCKET` out of a JS `net.Socket` by casting the `napi_value` to a `v8::Local`, reading V8's private internal-object fields (`GetAlignedPointerFromInternalField`), and heuristically scanning the wrapper's memory for the embedded `uv_tcp_t`.

That hack exists because Windows genuinely has no public path to the fd: `socket._handle.fd` is hard-coded to `-1` there (libuv wraps an opaque IOCP `SOCKET`, not a POSIX fd), unlike macOS/Linux where the existing fd handoff works fine.

But V8's internal-field/pointer-tagging layout is undocumented and **not ABI-stable** — it can change on any V8 roll, not just majors. The existing `#if V8_MAJOR_VERSION >= 14` guard in the code is evidence this already broke once before and was patched reactively; a compile-time version check fundamentally cannot protect a **prebuilt** binary that runs against a different Node/V8 build than it was compiled with. Any prebuild is one Node upgrade away from this crash, and when it lands it's undebuggable from JS.

## Why the obvious alternatives don't work

- **`socket._handle.fd`** — always `-1` on Windows (verified empirically on Node 24.15.0). This is a long-standing libuv/Windows property, not a regression; it's why the V8 hack was written in the first place.
- **Redialing `remoteAddress:remotePort` natively** — the CoreDeviceProxy socket is the product of a one-time, stateful usbmux exchange (send `Connect` plist → receive OK → the *same* socket is repurposed in place as the device stream). Its remote endpoint is usbmuxd's control port; a fresh connection there is a brand-new, unnegotiated session that ignores TLS bytes. Tested — fails with `SSL_connect timed out waiting to read`.

## Fix

Remove the V8-internals dependency entirely, in three parts:

1. **Loopback bridge (TS, `src/tunnel/forwarder.ts`)** — on `win32`, the already-negotiated socket is piped through a local `127.0.0.1` listener (`bridgeToNative()`); the listener closes after the first accept and is torn down with the forwarder. The negotiated usbmux session is never touched, extracted from, or redialed.
2. **Native WinSock dial (`ConnectRawTcp`, `src/native/tunnel_forwarder.cc`)** — native code connects to the bridge itself via plain `getaddrinfo`/`connect` and hands the resulting fd to the existing, unchanged `TunnelForwarder::Connect`/`ConnectPsk` — the same code path POSIX has always used. `connectSocket`/`connectPskSocket` (which took a JS handle) are replaced by `connectHost`/`connectPskHost` (which take `host, port`). The dialed socket is closed after `TunnelSslClient` duplicates it (`WSADuplicateSocketW`), and gets `TCP_NODELAY` to match the JS-side socket options.
3. **Async connect/handshake (`Napi::AsyncWorker`)** — the TLS connect and CDTunnel handshake block on socket I/O with a 15s deadline, and on Windows that I/O now flows through the JS-pumped bridge. If they ran synchronously on the JS thread they would deadlock against the very event loop that pumps their bytes. They now run on async workers and return promises. `handshake()` is a promise on all platforms (on POSIX this only stops the CDTunnel exchange from blocking the event loop; the protocol logic is untouched).

Additionally, a delay-load **failure hook** (`src/native/win_delay_load_failure_hook.cc`, `__pfnDliFailureHook2`) now reports the exact DLL/symbol on stderr before the process dies if any delay-load resolution ever fails again — so this class of failure can never be silent in the future. It changes nothing when resolution succeeds, and does not conflict with node-gyp's `__pfnDliNotifyHook2` hook.

## Compatibility

`dumpbin /IMPORTS` on the fixed binary: the `node.exe` delay-import table now contains **only `napi_*` symbols** (plus the OpenSSL C exports the prebuilds already relied on before this change). No `v8::*`, no `uv_*`. Node-API carries a formal ABI-stability guarantee, so a prebuild compiled once in CI (`NAPI_VERSION=8`) loads on every Node release that supports N-API 8 — including Node versions newer than the one CI built against, which is exactly the case that crashed before.

macOS/Linux keep their existing direct-fd handoff; the bridge and all WinSock code are `win32`/`_WIN32`-gated.

## Breaking changes

- The `TunnelForwarder` **class** methods `connect()`, `connectPsk()`, and `handshake()` are now async. The package-level entry points `connectToTunnelLockdown()` / `connectToTunnelPsk()` were already promise-returning and keep their exact signatures — callers using those (e.g. `appium-ios-remotexpc`) need no changes.
- Native methods `connectSocket`/`connectPskSocket` are removed in favor of `connectHost`/`connectPskHost` (internal surface, not exported from the package API).

## Testing

- **Windows 11 + Node v24.15.0, physical iPhone over USB**: full tunnel creation via `appium-ios-remotexpc` (lockdown → CoreDeviceProxy → TLS handshake → TUN interface up), where v1.2.2 crashed the process.
- **Windows unit suite**: passes (privileged cases under elevated PowerShell).
- **macOS**: branch built from source and verified — no regressions on the POSIX path, including the now-async handshake.
