### PR TITLE
fix(native): report TLS connect failures without dereferencing null

### DIFF
--- a/src/native/tunnel_ssl.cc
+++ b/src/native/tunnel_ssl.cc
@@ -109,6 +109,37 @@ int DuplicateSocketFd(int tcp_fd, std::string& error) {
 }
 #endif
 
+// Takes an owned copy of the caller's socket so the JS side can drop the
+// original as soon as Connect returns.
+int AcquireOwnedFd(int tcp_fd, std::string& error) {
+#ifdef _WIN32
+  return DuplicateSocketFd(tcp_fd, error);
+#else
+  const int fd = dup(tcp_fd);
+  if (fd < 0) {
+    error = std::string("dup of TCP socket failed: ") + strerror(errno);
+  }
+  return fd;
+#endif
+}
+
+// ERR_reason_error_string returns null when the queue is empty, which is the
+// normal case for SSL_ERROR_SYSCALL (peer reset, EOF mid-handshake).
+std::string DescribeConnectFailure(int ssl_error) {
+  const unsigned long queued = ERR_get_error();
+  const char* reason = queued == 0 ? nullptr : ERR_reason_error_string(queued);
+  if (reason != nullptr) {
+    return std::string("SSL_connect failed: ") + reason;
+  }
+#ifdef _WIN32
+  const int system_error = WSAGetLastError();
+#else
+  const int system_error = errno;
+#endif
+  return "SSL_connect failed: ssl_error=" + std::to_string(ssl_error) +
+         " system_error=" + std::to_string(system_error);
+}
+
 bool PollConnectFd(int fd, short events, std::chrono::steady_clock::time_point deadline) {
 #ifdef _WIN32
   WSAPOLLFD pfd {};
@@ -218,7 +249,7 @@ bool TunnelSslClient::ConnectTls(int timeout_ms, std::string& error) {
       }
       continue;
     }
-    error = std::string("SSL_connect failed: ") + ERR_reason_error_string(ERR_get_error());
+    error = DescribeConnectFailure(err);
     return false;
   }
 }
@@ -245,13 +276,8 @@ bool TunnelSslClient::Connect(int tcp_fd,
 #endif
 
   close_owned_fd_ = true;
-#ifdef _WIN32
-  owned_fd_ = DuplicateSocketFd(tcp_fd, error);
-#else
-  owned_fd_ = dup(tcp_fd);
-#endif
+  owned_fd_ = AcquireOwnedFd(tcp_fd, error);
   if (owned_fd_ < 0) {
-    error = "Failed to acquire TCP socket handle";
     return false;
   }
   SetNonBlockingFd(owned_fd_);
@@ -321,13 +347,8 @@ bool TunnelSslClient::ConnectPsk(int tcp_fd,
 #endif
 
   close_owned_fd_ = true;
-#ifdef _WIN32
-  owned_fd_ = DuplicateSocketFd(tcp_fd, error);
-#else
-  owned_fd_ = dup(tcp_fd);
-#endif
+  owned_fd_ = AcquireOwnedFd(tcp_fd, error);
   if (owned_fd_ < 0) {
-    error = "Failed to acquire TCP socket handle";
     return false;
   }
   SetNonBlockingFd(owned_fd_);


### PR DESCRIPTION
## Problem

`ConnectTls` built its error string as:

```cpp
error = std::string("SSL_connect failed: ") + ERR_reason_error_string(ERR_get_error());
```

`ERR_reason_error_string` returns `NULL` when the OpenSSL error queue is empty, which is the normal case for `SSL_ERROR_SYSCALL` — a peer reset or a transport error mid-handshake. Concatenating `NULL` into a `std::string` is undefined behaviour and segfaults the process, so a recoverable tunnel failure takes down the whole Node process with no diagnostic.

The same function also discarded the specific reason a socket handoff failed: `DuplicateSocketFd` writes a precise `WSAGetLastError()` message into `error`, which was then unconditionally overwritten with the generic `"Failed to acquire TCP socket handle"`.

## Change

- `DescribeConnectFailure()` checks the queued reason before using it and falls back to `ssl_error=<n> system_error=<n>` when the queue is empty.
- `AcquireOwnedFd()` folds the two duplicated `#ifdef` dup blocks into one helper and preserves the underlying `dup`/`WSADuplicateSocket` failure reason.

Error-reporting only — no change to connection or handshake behaviour.

## Verification

- `build:addon`, `build`, `lint`, `format:check` clean on macOS arm64; no new compiler diagnostics.
- `test:unit`: 9 passed, 0 failed, 5 skipped (privileged cases need root).
- Drove a real socket into the `SSL_connect` failure branch through the addon to confirm it is live code: threw `SSL_connect failed: unexpected eof while reading`.
- Standalone harness against the same OpenSSL 3.6.2 build: `ERR_reason_error_string(0)` is `NULL`, and the pre-fix expression exits **139 (SIGSEGV)**. The new helper returns `SSL_connect failed: ssl_error=5 system_error=54` on an empty queue and `SSL_connect failed: wrong version number` when a reason is queued.

Linux and Windows compilation is covered by the prebuild matrix rather than locally. No regression test is included — the TLS path needs a real device tunnel, and covering it would mean exposing the helper purely for tests.