### PR TITLE
fix(native): keep poll dispatch alive until queued callbacks drain

### DIFF
--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -11,23 +11,31 @@
 #include "native/tun_backend.h"
 #include "native/tunnel_forwarder.h"
 
-struct TunPollDispatch {
+struct TunPollDispatch : public std::enable_shared_from_this<TunPollDispatch> {
   Napi::ThreadSafeFunction tsfn;
   std::mutex mutex;
   std::deque<std::vector<uint8_t>> pending;
   size_t max_pending_ = 1;
   class TunDevice* device_ = nullptr;
 
+  // Each queued job keeps the dispatch alive, so it outlives a close that
+  // happens while callbacks are still draining.
   struct PacketJob {
-    TunPollDispatch* dispatch;
+    std::shared_ptr<TunPollDispatch> dispatch;
     std::vector<uint8_t>* packet;
   };
 
   void OnJsConsumed();
 
+  // Drop the device back-pointer so a late callback cannot resume a closing device.
+  void Detach() {
+    std::lock_guard<std::mutex> lock(mutex);
+    device_ = nullptr;
+  }
+
   static void CallJs(Napi::Env env,
                      Napi::Function jsCallback,
-                     TunPollDispatch* self,
+                     const std::shared_ptr<TunPollDispatch>& self,
                      std::vector<uint8_t>* packet) {
     if (env == nullptr || jsCallback.IsEmpty() || packet == nullptr) {
       delete packet;
@@ -41,7 +49,7 @@ struct TunPollDispatch {
         [](Napi::Env, uint8_t*, std::vector<uint8_t>* vec) { delete vec; },
         backing);
     jsCallback.Call({buf});
-    if (self != nullptr) {
+    if (self) {
       self->OnJsConsumed();
     }
   }
@@ -50,7 +58,7 @@ struct TunPollDispatch {
     std::lock_guard<std::mutex> lock(mutex);
     while (!pending.empty()) {
       auto* packet = new std::vector<uint8_t>(std::move(pending.front()));
-      auto* job = new PacketJob{this, packet};
+      auto* job = new PacketJob{shared_from_this(), packet};
       napi_status status = tsfn.NonBlockingCall(
           job,
           [](Napi::Env env, Napi::Function jsCallback, PacketJob* job) {
@@ -111,7 +119,7 @@ private:
   std::mutex device_mutex_;
 
   Napi::ThreadSafeFunction tsfn_;
-  TunPollDispatch* poll_dispatch_ = nullptr;
+  std::shared_ptr<TunPollDispatch> poll_dispatch_;
   std::atomic<bool> polling_;
   static constexpr size_t MAX_POLL_BUFFER = 65535;
 
@@ -328,12 +336,17 @@ Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
   }
 
   Napi::ThreadSafeFunction tsfn = tsfn_;
-  auto* dispatch = new TunPollDispatch();
+  auto dispatch = std::make_shared<TunPollDispatch>();
   dispatch->tsfn = tsfn;
   dispatch->max_pending_ = queue_depth;
   dispatch->device_ = this;
   poll_dispatch_ = dispatch;
-  auto packet_cb = [this, dispatch](std::vector<uint8_t> packet) mutable -> bool {
+  auto packet_cb = [this, weak_dispatch = std::weak_ptr<TunPollDispatch>(dispatch)](
+                       std::vector<uint8_t> packet) mutable -> bool {
+    const auto dispatch = weak_dispatch.lock();
+    if (!dispatch) {
+      return false;
+    }
     const bool accepted = dispatch->PostPacket(std::move(packet));
     if (polling_ && backend_) {
       // Pause until the JS callback runs (pmd3 reads one utun packet per iteration).
@@ -413,15 +426,15 @@ void TunDevice::StopPollingLocked() {
 }
 
 void TunDevice::ReleaseTsfnLocked() {
-  // Release TSFN first — it blocks until queued callbacks finish. Those callbacks
-  // may still dereference poll_dispatch_, so it must outlive the TSFN drain.
+  // Release() does not block: already-queued callbacks still run afterwards.
+  // They own the dispatch via shared_ptr, so dropping our reference here is safe.
+  if (poll_dispatch_) {
+    poll_dispatch_->Detach();
+    poll_dispatch_.reset();
+  }
   if (tsfn_) {
     tsfn_.Release();
     tsfn_ = nullptr;
-  }
-  if (poll_dispatch_ != nullptr) {
-    delete poll_dispatch_;
-    poll_dispatch_ = nullptr;
   }
 }
 


### PR DESCRIPTION
## Problem

`ReleaseTsfnLocked` released the thread-safe function and then deleted `TunPollDispatch` on the next line, justified by this comment:

```cpp
// Release TSFN first — it blocks until queued callbacks finish. Those callbacks
// may still dereference poll_dispatch_, so it must outlive the TSFN drain.
```

`napi_release_threadsafe_function` does not block. It marks the function for destruction and any already-queued items are still delivered to the JS thread afterwards. Each queued `PacketJob` carries a pointer to the dispatch and calls `self->OnJsConsumed()` on it, so closing the device while a packet sits in the TSFN queue frees the dispatch underneath a callback that is about to use it.

The window is narrow — the receive loop pauses after each packet, so typically at most one packet is in flight — but it is reachable whenever `close()` lands between a packet being queued and the queue draining.

## Change

- `PacketJob` holds a `std::shared_ptr<TunPollDispatch>`; `poll_dispatch_` becomes a `shared_ptr` that is `reset()` rather than deleted, so the last queued callback frees the dispatch.
- `Release()` is kept, so pending items still drain normally with a live env. (`Abort()` would instead leak the job and packet: node-addon-api's `CallJS` returns early when `env == nullptr && jsCallback == nullptr`, before deleting the `CallbackWrapper`.)
- `Detach()` clears the raw `device_` back-pointer under the dispatch mutex before the device drops its reference, so a late `OnJsConsumed` cannot call `ResumeReceiveFromDispatch` on a closing device.
- The packet callback captures a `weak_ptr` rather than a raw pointer.
- The inaccurate comment is corrected.

Lock order is unchanged: `Detach()` takes the dispatch mutex while `device_mutex_` is held, and `OnJsConsumed` releases the dispatch mutex before taking `device_mutex_` (the existing code already copies `device` out of the lock scope for that reason). A late `FlushPending` calling `NonBlockingCall` on the released TSFN gets `napi_closing`, which the existing non-`napi_ok` branch already frees and breaks on.

## Verification

- `build:addon` clean on macOS arm64, no new compiler diagnostics; `build` and `lint` clean.
- `test:unit`: 9 passed, 0 failed, 5 skipped (privileged).

**Not runtime-verified.** No test in the suite exercises `startPolling`, and reproducing the window needs an open utun, i.e. root. A stress harness for it opens a utun, polls, drives traffic through it with `ping6`, and closes at a randomized point mid-flight so `close()` lands with packets queued; a clean run is N rounds with non-zero packets, zero callbacks after close, and no crash. Worth running under `sudo` before merge. Being a use-after-free, a pre-fix build may survive such a run anyway, so a passing run on the old code would not be evidence against the bug.