### PR TITLE
fix(native): read CDTunnel header length via memcpy

### DIFF
--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -448,7 +448,10 @@ bool TunnelForwarder::Handshake(uint32_t requested_mtu, TunnelHandshakeInfo& inf
     error = "Invalid CDTunnel magic in handshake response";
     return false;
   }
-  const uint16_t payload_len = ntohs(*reinterpret_cast<uint16_t*>(header + 8));
+  // header is a byte array, so copy the length out rather than aliasing it as uint16_t.
+  uint16_t payload_len_be = 0;
+  std::memcpy(&payload_len_be, header + 8, sizeof(payload_len_be));
+  const uint16_t payload_len = ntohs(payload_len_be);
   std::vector<uint8_t> body(payload_len);
   if (payload_len > 0 && SslReadExact(body.data(), body.size()) < 0) {
     error = Clock::now() >= handshake_deadline_ ? "Tunnel handshake timeout"


### PR DESCRIPTION
## Problem

`TunnelForwarder::Handshake` reads the 10-byte CDTunnel response header into a byte array and then decodes the length field by aliasing it:

```cpp
uint8_t header[kCdTunnelHeaderSize];
...
const uint16_t payload_len = ntohs(*reinterpret_cast<uint16_t*>(header + 8));
```

Two problems with that load:

- **Strict aliasing.** Accessing `uint8_t` objects through a `uint16_t` lvalue is undefined behaviour regardless of address. This is unconditional, not situational.
- **Alignment.** `uint8_t[]` only guarantees 1-byte alignment, while a `uint16_t` load requires 2. In practice the compiler usually aligns this particular stack array well enough that `header + 8` is even, so it is unlikely to misbehave *today* — but nothing in the language guarantees it, and it is exactly the kind of construct that breaks on a compiler upgrade or when the surrounding code is refactored.

## Change

Copy the two bytes into a `uint16_t` before the byte swap. Same instruction sequence after optimisation, no UB.

## Verification

- `build:addon` clean on macOS arm64, no new diagnostics; `build`, `lint`, `format:check` clean.
- `test:unit`: 9 passed, 0 failed, 5 skipped (privileged cases need root).
- Standalone harness decoding the same header both ways at a deliberately odd address: both yield `1042`, so the change is behaviour-preserving. Built with `-fsanitize=undefined`, the old form reports `runtime error: load of misaligned address ... which requires 2 byte alignment` and aborts (exit 134); the `memcpy` form is clean.

The forced misalignment in that harness is what makes the fault observable — it demonstrates the defect class rather than a failure occurring in the current build.