### PR TITLE
chore(native): drop unused members

### DIFF
--- a/src/native/tunnel_ssl.cc
+++ b/src/native/tunnel_ssl.cc
@@ -275,7 +275,6 @@ bool TunnelSslClient::Connect(int tcp_fd,
   }
 #endif
 
-  close_owned_fd_ = true;
   owned_fd_ = AcquireOwnedFd(tcp_fd, error);
   if (owned_fd_ < 0) {
     return false;
@@ -346,7 +345,6 @@ bool TunnelSslClient::ConnectPsk(int tcp_fd,
   }
 #endif
 
-  close_owned_fd_ = true;
   owned_fd_ = AcquireOwnedFd(tcp_fd, error);
   if (owned_fd_ < 0) {
     return false;
@@ -398,17 +396,14 @@ void TunnelSslClient::Close() {
     SSL_CTX_free(ctx_);
     ctx_ = nullptr;
   }
-  if (owned_fd_ >= 0 && close_owned_fd_) {
+  if (owned_fd_ >= 0) {
 #ifdef _WIN32
     closesocket(static_cast<SOCKET>(owned_fd_));
 #else
     ::close(owned_fd_);
 #endif
-  }
-  if (owned_fd_ >= 0) {
     owned_fd_ = -1;
   }
-  close_owned_fd_ = true;
   psk_key_.clear();
   psk_identity_.clear();
 }

--- a/src/native/tunnel_ssl.h
+++ b/src/native/tunnel_ssl.h
@@ -49,7 +49,6 @@ private:
   SSL_CTX* ctx_ = nullptr;
   SSL* ssl_ = nullptr;
   int owned_fd_ = -1;
-  bool close_owned_fd_ = true;
   std::vector<uint8_t> psk_key_;
   std::string psk_identity_;
 };

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -99,7 +99,6 @@ public:
 
 private:
   friend struct TunPollDispatch;
-  static Napi::FunctionReference constructor;
 
   Napi::Value Open(const Napi::CallbackInfo& info);
   Napi::Value Close(const Napi::CallbackInfo& info);
@@ -125,10 +124,7 @@ private:
 
   void StopPollingLocked();
   void ReleaseTsfnLocked();
-  void PauseReceiveFromDispatch();
 };
-
-Napi::FunctionReference TunDevice::constructor;
 
 Napi::Object TunDevice::Init(Napi::Env env, Napi::Object exports) {
   Napi::HandleScope scope(env);
@@ -145,9 +141,6 @@ Napi::Object TunDevice::Init(Napi::Env env, Napi::Object exports) {
     InstanceMethod("pausePolling", &TunDevice::PausePolling),
     InstanceMethod("resumePolling", &TunDevice::ResumePolling),
   });
-
-  constructor = Napi::Persistent(func);
-  constructor.SuppressDestruct();
 
   exports.Set("TunDevice", func);
   return exports;
@@ -449,13 +442,6 @@ void TunPollDispatch::OnJsConsumed() {
   }
   if (device != nullptr) {
     device->ResumeReceiveFromDispatch();
-  }
-}
-
-void TunDevice::PauseReceiveFromDispatch() {
-  std::lock_guard<std::mutex> lock(device_mutex_);
-  if (polling_ && backend_) {
-    backend_->PauseReceiveLoop();
   }
 }
 


### PR DESCRIPTION
Three stale members nothing uses

- `TunDevice::constructor` — assigned in `Init`, never read. The class is kept alive by the module exports.
- `PauseReceiveFromDispatch()` — no callers; the packet callback pauses the backend directly.
- `close_owned_fd_` — only ever set true, so its guard in `Close()` was always taken.

No behaviour change. 