### PR TITLE
fix(native): address clang-tidy warnings across native sources

### DIFF
--- a/.github/workflows/shared.yml
+++ b/.github/workflows/shared.yml
@@ -117,6 +117,12 @@ jobs:
       if: ${{ contains(inputs.image, 'ubuntu') && inputs.run-cpp-lint }}
       run: sudo apt-get install -y clang-tidy
 
+    - name: Install clang-tidy (macOS)
+      if: ${{ contains(inputs.image, 'macos') && inputs.run-cpp-lint }}
+      run: |
+        brew install llvm
+        echo "$(brew --prefix llvm)/bin" >> "$GITHUB_PATH"
+
     - name: Run C++ format check
       if: ${{ inputs.run-cpp-format-check }}
       run: npm run format:cpp:check

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -34,4 +34,4 @@ jobs:
       run-lint: ${{ contains(matrix.image, 'ubuntu') }}
       run-format-check: ${{ contains(matrix.image, 'ubuntu') }}
       run-cpp-format-check: ${{ contains(matrix.image, 'ubuntu') }}
-      run-cpp-lint: ${{ contains(matrix.image, 'ubuntu') }}
+      run-cpp-lint: ${{ contains(matrix.image, 'ubuntu') || contains(matrix.image, 'macos') }}

--- a/src/native/debug_log.cc
+++ b/src/native/debug_log.cc
@@ -31,17 +31,22 @@ void FwdDebug(const char* event) {
     return;
   }
 
-  std::lock_guard<std::mutex> lock(g_log_mutex);
+  std::scoped_lock lock(g_log_mutex);
   fprintf(stderr, "[fwd] #%llu %s\n", static_cast<unsigned long long>(++g_seq), event);
   fflush(stderr);
 }
 
+// Kept as a C-style variadic printf-style logger (rather than a variadic
+// template) so the 17 call sites across tunnel_forwarder.cc/tunnel_ssl.cc can
+// keep using plain printf format strings, compiler-checked via the
+// __attribute__((format(printf, ...))) on the declaration in debug_log.h.
+// NOLINTNEXTLINE(modernize-avoid-variadic-functions)
 void FwdDebug(const char* event, const char* fmt, ...) {
   if (!DebugEnabled()) {
     return;
   }
 
-  std::lock_guard<std::mutex> lock(g_log_mutex);
+  std::scoped_lock lock(g_log_mutex);
   fprintf(stderr, "[fwd] #%llu %s ", static_cast<unsigned long long>(++g_seq), event);
 
   va_list args;

--- a/src/native/file_descriptor.h
+++ b/src/native/file_descriptor.h
@@ -12,9 +12,9 @@ class FileDescriptor {
   FileDescriptor(FileDescriptor&& other) noexcept;
   FileDescriptor& operator=(FileDescriptor&& other) noexcept;
 
-  int get() const;
+  [[nodiscard]] int get() const;
   int release();
-  bool is_valid() const;
+  [[nodiscard]] bool is_valid() const;
   void reset(int fd = -1);
 
  private:

--- a/src/native/posix_tun_backend.h
+++ b/src/native/posix_tun_backend.h
@@ -26,7 +26,7 @@ class PosixTunBackend : public TunPlatformBackend {
     interface_name_.clear();
   }
 
-  bool IsOpen() const override { return fd_.is_valid(); }
+  [[nodiscard]] bool IsOpen() const override { return fd_.is_valid(); }
 
   bool StartReceiveLoop(uv_loop_t* loop, size_t buffer_size, PacketCallback on_packet, ErrorCallback on_error,
                         std::string& error) override {
@@ -46,7 +46,7 @@ class PosixTunBackend : public TunPlatformBackend {
 
   void ResumeReceiveLoop() override { poll_loop_.Resume(); }
 
-  int GetNativeFd() const override { return fd_.get(); }
+  [[nodiscard]] int GetNativeFd() const override { return fd_.get(); }
 
   bool WaitReadable(const std::atomic<bool>& running, std::string& error) override {
     return WaitForEvents(POLLIN, running, error);

--- a/src/native/posix_uv_poll_loop.cc
+++ b/src/native/posix_uv_poll_loop.cc
@@ -2,10 +2,10 @@
 
 #include "posix_uv_poll_loop.h"
 
+#include <cerrno>
 #include <cstdio>
-#include <errno.h>
+#include <cstring>
 #include <fcntl.h>
-#include <string.h>
 #include <utility>
 
 PosixUvPollLoop::~PosixUvPollLoop() { Stop(); }
@@ -13,11 +13,11 @@ PosixUvPollLoop::~PosixUvPollLoop() { Stop(); }
 bool PosixUvPollLoop::Start(uv_loop_t* loop, int fd, size_t buffer_size, ReadFn read_fn,
                             TunPlatformBackend::PacketCallback on_packet, TunPlatformBackend::ErrorCallback on_error,
                             std::string& error) {
-  if (handle_) {
+  if (handle_ != nullptr) {
     error = "Receive loop already started";
     return false;
   }
-  if (!loop || fd < 0 || buffer_size == 0) {
+  if (loop == nullptr || fd < 0 || buffer_size == 0) {
     error = "Invalid receive-loop parameters";
     return false;
   }
@@ -49,7 +49,7 @@ bool PosixUvPollLoop::Start(uv_loop_t* loop, int fd, size_t buffer_size, ReadFn 
 }
 
 void PosixUvPollLoop::Stop() {
-  if (!handle_) {
+  if (handle_ == nullptr) {
     return;
   }
 
@@ -62,7 +62,7 @@ void PosixUvPollLoop::Stop() {
 }
 
 void PosixUvPollLoop::Pause() {
-  if (!handle_ || paused_) {
+  if (handle_ == nullptr || paused_) {
     return;
   }
   paused_ = true;
@@ -70,7 +70,7 @@ void PosixUvPollLoop::Pause() {
 }
 
 void PosixUvPollLoop::Resume() {
-  if (!handle_ || !paused_) {
+  if (handle_ == nullptr || !paused_) {
     return;
   }
   paused_ = false;
@@ -79,7 +79,7 @@ void PosixUvPollLoop::Resume() {
 
 void PosixUvPollLoop::OnPoll(uv_poll_t* handle, int status, int events) {
   auto* state = static_cast<State*>(handle->data);
-  if (!state) {
+  if (state == nullptr) {
     return;
   }
 
@@ -102,7 +102,7 @@ void PosixUvPollLoop::OnPoll(uv_poll_t* handle, int status, int events) {
     return;
   }
 
-  if (!(events & UV_READABLE) || !state->read_fn) {
+  if ((events & UV_READABLE) == 0 || !state->read_fn) {
     return;
   }
 

--- a/src/native/tun_backend.h
+++ b/src/native/tun_backend.h
@@ -21,7 +21,7 @@ using ssize_t = SSIZE_T;
 
 #include <uv.h>
 
-enum class ReadPacketStatus {
+enum class ReadPacketStatus : std::uint8_t {
   Data,
   NoData,
   Closed,
@@ -53,7 +53,7 @@ class TunPlatformBackend {
 
   virtual bool OpenDevice(const std::string& requested_name, std::string& out_interface_name, std::string& error) = 0;
   virtual void CloseDevice() = 0;
-  virtual bool IsOpen() const = 0;
+  [[nodiscard]] virtual bool IsOpen() const = 0;
 
   virtual ReadPacketStatus ReadPacket(size_t max_payload_size, std::vector<uint8_t>& out, std::string& error) = 0;
   virtual ssize_t WritePacket(const uint8_t* data, size_t length, std::string& error) = 0;
@@ -76,7 +76,7 @@ class TunPlatformBackend {
 
   // Returns the underlying POSIX file descriptor when one exists. Backends
   // without a numeric fd (e.g. Wintun on Windows) return `-1`.
-  virtual int GetNativeFd() const { return -1; }
+  [[nodiscard]] virtual int GetNativeFd() const { return -1; }
 };
 
 std::unique_ptr<TunPlatformBackend> CreatePlatformBackend();

--- a/src/native/tun_backend_darwin.cc
+++ b/src/native/tun_backend_darwin.cc
@@ -2,8 +2,8 @@
 
 #include "tun_backend.h"
 
-#include <errno.h>
-#include <string.h>
+#include <cerrno>
+#include <cstring>
 #include <sys/ioctl.h>
 #include <sys/kern_control.h>
 #include <sys/socket.h>
@@ -14,6 +14,7 @@
 #include <netinet/in.h>
 #include <netinet6/in6_var.h>
 
+#include <array>
 #include <utility>
 
 #include "file_descriptor.h"
@@ -29,8 +30,8 @@ class DarwinTunBackend : public PosixTunBackend {
   static constexpr size_t kUtunHeaderSize = 4;
 
   bool OpenDevice(const std::string& requested_name, std::string& out_interface_name, std::string& error) override {
-    struct ctl_info ctl_info;
-    struct sockaddr_ctl socket_addr;
+    struct ctl_info ctl_info {};
+    struct sockaddr_ctl socket_addr {};
 
     FileDescriptor temp_fd(socket(PF_SYSTEM, SOCK_DGRAM, SYSPROTO_CONTROL));
     if (!temp_fd.is_valid()) {
@@ -64,9 +65,9 @@ class DarwinTunBackend : public PosixTunBackend {
       return false;
     }
 
-    char interface_name[20];
-    socklen_t interface_name_len = sizeof(interface_name);
-    if (getsockopt(temp_fd.get(), SYSPROTO_CONTROL, UTUN_OPT_IFNAME, interface_name, &interface_name_len) < 0) {
+    std::array<char, 20> interface_name{};
+    socklen_t interface_name_len = interface_name.size();
+    if (getsockopt(temp_fd.get(), SYSPROTO_CONTROL, UTUN_OPT_IFNAME, interface_name.data(), &interface_name_len) < 0) {
       error = std::string("Failed to get utun interface name: ") + strerror(errno);
       return false;
     }
@@ -76,7 +77,7 @@ class DarwinTunBackend : public PosixTunBackend {
     }
 
     fd_ = std::move(temp_fd);
-    interface_name_ = std::string(interface_name);
+    interface_name_ = std::string(interface_name.data());
     out_interface_name = interface_name_;
     return true;
   }

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -1,5 +1,6 @@
 #include "tunnel_forwarder.h"
 
+#include <array>
 #include <cerrno>
 #include <cstdio>
 #include <cstring>
@@ -22,9 +23,9 @@
 
 namespace {
 
-constexpr char kCdTunnelMagic[] = "CDTunnel";
+constexpr const char* kCdTunnelMagic = "CDTunnel";
 constexpr size_t kCdTunnelHeaderSize = 10;
-constexpr size_t kMaxIngressBuffer = 256 * 1024;
+constexpr size_t kMaxIngressBuffer = size_t{256} * 1024;
 
 #ifdef _WIN32
 constexpr short kPollIn = POLLRDNORM;
@@ -240,11 +241,11 @@ bool NormalizeTcpChecksum(std::vector<uint8_t>& packet, uint16_t& old_checksum, 
 #endif
 
 std::string FormatIpv6Address(const uint8_t* addr) {
-  char buf[40];
-  std::snprintf(buf, sizeof(buf), "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x", addr[0],
-                addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7], addr[8], addr[9], addr[10], addr[11],
-                addr[12], addr[13], addr[14], addr[15]);
-  return buf;
+  std::array<char, 40> buf{};
+  std::snprintf(buf.data(), buf.size(), "%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x:%02x%02x",
+                addr[0], addr[1], addr[2], addr[3], addr[4], addr[5], addr[6], addr[7], addr[8], addr[9], addr[10],
+                addr[11], addr[12], addr[13], addr[14], addr[15]);
+  return buf.data();
 }
 
 void DebugIpv6Packet(const char* tag, const uint8_t* data, size_t len, uint64_t count) {
@@ -255,14 +256,14 @@ void DebugIpv6Packet(const char* tag, const uint8_t* data, size_t len, uint64_t 
     tuntap::FwdDebug(tag, "len=%zu packets=%llu non-ipv6", len, static_cast<unsigned long long>(count));
     return;
   }
-  const uint16_t payload_len = static_cast<uint16_t>((data[4] << 8) | data[5]);
+  const auto payload_len = static_cast<uint16_t>((data[4] << 8) | data[5]);
   const std::string src = FormatIpv6Address(data + 8);
   const std::string dst = FormatIpv6Address(data + 24);
 
   if (data[6] == 6 && len >= 60) {
     const size_t tcp_offset = 40;
-    const uint16_t src_port = static_cast<uint16_t>((data[tcp_offset] << 8) | data[tcp_offset + 1]);
-    const uint16_t dst_port = static_cast<uint16_t>((data[tcp_offset + 2] << 8) | data[tcp_offset + 3]);
+    const auto src_port = static_cast<uint16_t>((data[tcp_offset] << 8) | data[tcp_offset + 1]);
+    const auto dst_port = static_cast<uint16_t>((data[tcp_offset + 2] << 8) | data[tcp_offset + 3]);
     const uint8_t flags = data[tcp_offset + 13];
     tuntap::FwdDebug(tag, "len=%zu packets=%llu next=%u payload=%u %s:%u -> %s:%u flags=0x%02x", len,
                      static_cast<unsigned long long>(count), data[6], payload_len, src.c_str(), src_port, dst.c_str(),
@@ -349,7 +350,7 @@ void TunnelForwarder::Fail(const std::string& reason) {
 
   ForwarderErrorCallback cb;
   {
-    std::lock_guard<std::mutex> lock(error_mutex_);
+    std::scoped_lock lock(error_mutex_);
     cb = std::move(on_error_);
     on_error_ = nullptr;
   }
@@ -378,7 +379,7 @@ bool TunnelForwarder::Handshake(uint32_t requested_mtu, TunnelHandshakeInfo& inf
 
   handshake_deadline_ = Clock::now() + std::chrono::milliseconds(kTunnelHandshakeTimeoutMs);
 
-  const std::string request = "{\"type\":\"clientHandshakeRequest\",\"mtu\":" + std::to_string(requested_mtu) + "}";
+  const std::string request = R"({"type":"clientHandshakeRequest","mtu":)" + std::to_string(requested_mtu) + "}";
   const std::string packet = EncodeCdTunnelMessage(request);
   if (SslWriteAll(reinterpret_cast<const uint8_t*>(packet.data()), packet.size(), false) < 0) {
     error =
@@ -386,19 +387,19 @@ bool TunnelForwarder::Handshake(uint32_t requested_mtu, TunnelHandshakeInfo& inf
     return false;
   }
 
-  uint8_t header[kCdTunnelHeaderSize];
-  if (SslReadExact(header, kCdTunnelHeaderSize) < 0) {
+  std::array<uint8_t, kCdTunnelHeaderSize> header{};
+  if (SslReadExact(header.data(), header.size()) < 0) {
     error =
         Clock::now() >= handshake_deadline_ ? "Tunnel handshake timeout" : "Failed to read CDTunnel handshake header";
     return false;
   }
-  if (std::memcmp(header, kCdTunnelMagic, 8) != 0) {
+  if (std::memcmp(header.data(), kCdTunnelMagic, 8) != 0) {
     error = "Invalid CDTunnel magic in handshake response";
     return false;
   }
   // header is a byte array, so copy the length out rather than aliasing it as uint16_t.
   uint16_t payload_len_be = 0;
-  std::memcpy(&payload_len_be, header + 8, sizeof(payload_len_be));
+  std::memcpy(&payload_len_be, header.data() + 8, sizeof(payload_len_be));
   const uint16_t payload_len = ntohs(payload_len_be);
   std::vector<uint8_t> body(payload_len);
   if (payload_len > 0 && SslReadExact(body.data(), body.size()) < 0) {
@@ -440,7 +441,7 @@ bool TunnelForwarder::StartForwarding(TunPlatformBackend* tun_backend, Forwarder
 
   error_reported_.store(false);
   {
-    std::lock_guard<std::mutex> lock(error_mutex_);
+    std::scoped_lock lock(error_mutex_);
     on_error_ = std::move(on_error);
   }
 
@@ -459,7 +460,7 @@ void TunnelForwarder::Stop() {
   running_.store(false);
 
   {
-    std::lock_guard<std::mutex> lock(ssl_mutex_);
+    std::scoped_lock lock(ssl_mutex_);
     if (ssl_.ssl() != nullptr) {
       SSL_shutdown(ssl_.ssl());
     }
@@ -473,7 +474,7 @@ void TunnelForwarder::Stop() {
   }
 
   {
-    std::lock_guard<std::mutex> lock(error_mutex_);
+    std::scoped_lock lock(error_mutex_);
     on_error_ = nullptr;
   }
 
@@ -502,7 +503,7 @@ ssize_t TunnelForwarder::SslReadChunk(uint8_t* buf, size_t max_len, bool only_wh
     short poll_events = 0;
 
     {
-      std::lock_guard<std::mutex> lock(ssl_mutex_);
+      std::scoped_lock lock(ssl_mutex_);
       SSL* ssl = ssl_.ssl();
       if (ssl == nullptr) {
         return -1;
@@ -561,7 +562,7 @@ ssize_t TunnelForwarder::SslWriteAll(const uint8_t* data, size_t len, bool only_
     short poll_events = 0;
 
     {
-      std::lock_guard<std::mutex> lock(ssl_mutex_);
+      std::scoped_lock lock(ssl_mutex_);
       SSL* ssl = ssl_.ssl();
       if (ssl == nullptr) {
         return -1;
@@ -715,10 +716,10 @@ void TunnelForwarder::TunToDeviceLoop() {
 
 void TunnelForwarder::DeviceToTunLoop() {
   std::vector<uint8_t> ingress;
-  uint8_t chunk[16384];
+  std::array<uint8_t, 16384> chunk{};
 
   while (running_.load()) {
-    const ssize_t n = SslReadChunk(chunk, sizeof(chunk));
+    const ssize_t n = SslReadChunk(chunk.data(), chunk.size());
     if (n < 0) {
       if (running_.load()) {
         Fail("SSL read failed in device-to-tun loop");
@@ -738,7 +739,7 @@ void TunnelForwarder::DeviceToTunLoop() {
       Fail("SSL ingress buffer overflow");
       return;
     }
-    ingress.insert(ingress.end(), chunk, chunk + n);
+    ingress.insert(ingress.end(), chunk.begin(), chunk.begin() + n);
 
     std::vector<std::vector<uint8_t>> frames;
     ipv6_frame::DrainFrames(ingress, frames);
@@ -777,6 +778,7 @@ class ConnectHostWorker : public Napi::AsyncWorker {
         key_pem_(std::move(key_pem)),
         deferred_(deferred) {}
 
+ protected:
   void Execute() override {
     std::string error;
     int fd = -1;
@@ -819,6 +821,7 @@ class ConnectPskHostWorker : public Napi::AsyncWorker {
         identity_(std::move(identity)),
         deferred_(deferred) {}
 
+ protected:
   void Execute() override {
     std::string error;
     int fd = -1;
@@ -857,6 +860,7 @@ class HandshakeWorker : public Napi::AsyncWorker {
         requested_mtu_(requested_mtu),
         deferred_(deferred) {}
 
+ protected:
   void Execute() override {
     std::string error;
     if (!forwarder_.Handshake(requested_mtu_, handshake_, error)) {
@@ -889,6 +893,8 @@ class HandshakeWorker : public Napi::AsyncWorker {
 
 }  // namespace
 
+namespace {
+
 class TunnelForwarderWrap : public Napi::ObjectWrap<TunnelForwarderWrap> {
  public:
   static Napi::Object Init(Napi::Env env, Napi::Object exports) {
@@ -913,16 +919,16 @@ class TunnelForwarderWrap : public Napi::ObjectWrap<TunnelForwarderWrap> {
 
  private:
   void ReleaseErrorTsfn() {
-    std::lock_guard<std::mutex> lock(error_tsfn_mutex_);
-    if (error_tsfn_) {
+    std::scoped_lock lock(error_tsfn_mutex_);
+    if (error_tsfn_ != nullptr) {
       error_tsfn_.Release();
       error_tsfn_ = nullptr;
     }
   }
 
   void ReportError(std::string message) {
-    std::lock_guard<std::mutex> lock(error_tsfn_mutex_);
-    if (!error_tsfn_) {
+    std::scoped_lock lock(error_tsfn_mutex_);
+    if (error_tsfn_ == nullptr) {
       return;
     }
     auto* copy = new std::string(std::move(message));
@@ -952,6 +958,10 @@ class TunnelForwarderWrap : public Napi::ObjectWrap<TunnelForwarderWrap> {
     return env.Undefined();
   }
 
+  // Only touches `forwarder_` inside the #ifdef _WIN32 branch below, so on
+  // non-Windows builds clang-tidy sees no instance-state use and suggests
+  // static; that would break the Windows build, which does use `forwarder_`.
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   Napi::Value ConnectHost(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     if (info.Length() < 4 || !info[0].IsString() || !info[1].IsNumber() || !info[2].IsString() || !info[3].IsString()) {
@@ -985,7 +995,7 @@ class TunnelForwarderWrap : public Napi::ObjectWrap<TunnelForwarderWrap> {
       identity = info[2].As<Napi::String>().Utf8Value();
     }
 
-    Napi::Buffer<uint8_t> psk = info[1].As<Napi::Buffer<uint8_t>>();
+    auto psk = info[1].As<Napi::Buffer<uint8_t>>();
     std::string error;
     if (!forwarder_.ConnectPsk(info[0].As<Napi::Number>().Int32Value(), psk.Data(), psk.Length(), identity, error)) {
       Napi::Error::New(env, error).ThrowAsJavaScriptException();
@@ -993,6 +1003,9 @@ class TunnelForwarderWrap : public Napi::ObjectWrap<TunnelForwarderWrap> {
     return env.Undefined();
   }
 
+  // Only touches `forwarder_` inside the #ifdef _WIN32 branch below; see the
+  // NOLINT rationale on ConnectHost above.
+  // NOLINTNEXTLINE(readability-convert-member-functions-to-static)
   Napi::Value ConnectPskHost(const Napi::CallbackInfo& info) {
     Napi::Env env = info.Env();
     if (info.Length() < 3 || !info[0].IsString() || !info[1].IsNumber() || !info[2].IsBuffer()) {
@@ -1054,7 +1067,7 @@ class TunnelForwarderWrap : public Napi::ObjectWrap<TunnelForwarderWrap> {
     }
 
     {
-      std::lock_guard<std::mutex> lock(error_tsfn_mutex_);
+      std::scoped_lock lock(error_tsfn_mutex_);
       error_tsfn_ = Napi::ThreadSafeFunction::New(env, on_error, "TunnelForwarderOnError", 0, 1);
     }
 
@@ -1078,6 +1091,8 @@ class TunnelForwarderWrap : public Napi::ObjectWrap<TunnelForwarderWrap> {
   std::mutex error_tsfn_mutex_;
   Napi::ThreadSafeFunction error_tsfn_;
 };
+
+}  // namespace
 
 Napi::Object InitTunnelForwarder(Napi::Env env, Napi::Object exports) {
   return TunnelForwarderWrap::Init(env, exports);

--- a/src/native/tunnel_forwarder.h
+++ b/src/native/tunnel_forwarder.h
@@ -23,7 +23,7 @@ struct TunnelHandshakeInfo {
 
 using ForwarderErrorCallback = std::function<void(std::string)>;
 
-enum class TunReadResult {
+enum class TunReadResult : std::uint8_t {
   kOk,
   kWouldBlock,
   kFatal,
@@ -72,7 +72,7 @@ class TunnelForwarder {
   std::atomic<uint64_t> tun_writes_{0};
   std::atomic<uint64_t> tun_drops_{0};
   std::atomic<uint64_t> ssl_reads_{0};
-  std::chrono::steady_clock::time_point handshake_deadline_{};
+  std::chrono::steady_clock::time_point handshake_deadline_;
   std::thread tun_thread_;
   std::thread sock_thread_;
 };

--- a/src/native/tunnel_ssl.cc
+++ b/src/native/tunnel_ssl.cc
@@ -23,7 +23,7 @@
 
 namespace {
 
-constexpr char kAppleTvPskCiphers[] = "PSK-AES256-CBC-SHA:PSK-AES128-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-RC4-SHA:PSK";
+constexpr const char* kAppleTvPskCiphers = "PSK-AES256-CBC-SHA:PSK-AES128-CBC-SHA:PSK-3DES-EDE-CBC-SHA:PSK-RC4-SHA:PSK";
 
 #ifdef _WIN32
 constexpr short kPollIn = POLLRDNORM;

--- a/src/native/tunnel_ssl.h
+++ b/src/native/tunnel_ssl.h
@@ -26,7 +26,7 @@ class TunnelSslClient {
 
   void Close();
 
-  SSL* ssl() const { return ssl_; }
+  [[nodiscard]] SSL* ssl() const { return ssl_; }
 
  private:
   static unsigned int PskClientCallback(SSL* ssl, const char* /*hint*/, char* identity, unsigned int max_identity_len,

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -11,12 +11,16 @@
 #include "native/tun_backend.h"
 #include "native/tunnel_forwarder.h"
 
+class TunDevice;
+
+namespace {
+
 struct TunPollDispatch : public std::enable_shared_from_this<TunPollDispatch> {
   Napi::ThreadSafeFunction tsfn;
   std::mutex mutex;
   std::deque<std::vector<uint8_t>> pending;
   size_t max_pending_ = 1;
-  class TunDevice* device_ = nullptr;
+  TunDevice* device_ = nullptr;
 
   // Each queued job keeps the dispatch alive, so it outlives a close that
   // happens while callbacks are still draining.
@@ -29,7 +33,7 @@ struct TunPollDispatch : public std::enable_shared_from_this<TunPollDispatch> {
 
   // Drop the device back-pointer so a late callback cannot resume a closing device.
   void Detach() {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
     device_ = nullptr;
   }
 
@@ -50,7 +54,7 @@ struct TunPollDispatch : public std::enable_shared_from_this<TunPollDispatch> {
   }
 
   void FlushPending() {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
     while (!pending.empty()) {
       auto* packet = new std::vector<uint8_t>(std::move(pending.front()));
       auto* job = new PacketJob{shared_from_this(), packet};
@@ -69,23 +73,25 @@ struct TunPollDispatch : public std::enable_shared_from_this<TunPollDispatch> {
 
   bool PostPacket(std::vector<uint8_t> packet) {
     {
-      std::lock_guard<std::mutex> lock(mutex);
+      std::scoped_lock lock(mutex);
       if (pending.size() >= max_pending_) {
         return false;
       }
       pending.push_back(std::move(packet));
     }
     FlushPending();
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
     return pending.size() < max_pending_;
   }
 };
+
+}  // namespace
 
 class TunDevice : public Napi::ObjectWrap<TunDevice> {
  public:
   static Napi::Object Init(Napi::Env env, Napi::Object exports);
   TunDevice(const Napi::CallbackInfo& info);
-  ~TunDevice();
+  ~TunDevice() override;
 
   void CloseInternal();
   void ResumeReceiveFromDispatch();
@@ -151,13 +157,13 @@ TunDevice::TunDevice(const Napi::CallbackInfo& info)
 }
 
 TunDevice::~TunDevice() {
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
   CloseInternal();
 }
 
 Napi::Value TunDevice::Open(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
 
   if (is_open_) {
     return Napi::Boolean::New(env, true);
@@ -181,14 +187,14 @@ Napi::Value TunDevice::Open(const Napi::CallbackInfo& info) {
 
 Napi::Value TunDevice::Close(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
   CloseInternal();
   return Napi::Boolean::New(env, true);
 }
 
 Napi::Value TunDevice::Read(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
 
   if (!is_open_ || !backend_ || !backend_->IsOpen()) {
     Napi::Error::New(env, "Device not open").ThrowAsJavaScriptException();
@@ -213,14 +219,14 @@ Napi::Value TunDevice::Read(const Napi::CallbackInfo& info) {
     return env.Null();
   }
   if (rs == ReadPacketStatus::NoData || rs == ReadPacketStatus::Closed) {
-    return Napi::Buffer<uint8_t>::New(env, 0);
+    return {env, Napi::Buffer<uint8_t>::New(env, 0)};
   }
-  return Napi::Buffer<uint8_t>::Copy(env, packet.data(), packet.size());
+  return {env, Napi::Buffer<uint8_t>::Copy(env, packet.data(), packet.size())};
 }
 
 Napi::Value TunDevice::Write(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
 
   if (!is_open_ || !backend_ || !backend_->IsOpen()) {
     Napi::Error::New(env, "Device not open").ThrowAsJavaScriptException();
@@ -232,7 +238,7 @@ Napi::Value TunDevice::Write(const Napi::CallbackInfo& info) {
     return Napi::Number::New(env, -1);
   }
 
-  Napi::Buffer<uint8_t> buffer = info[0].As<Napi::Buffer<uint8_t>>();
+  auto buffer = info[0].As<Napi::Buffer<uint8_t>>();
   uint8_t* data = buffer.Data();
   size_t length = buffer.Length();
 
@@ -246,18 +252,18 @@ Napi::Value TunDevice::Write(const Napi::CallbackInfo& info) {
 }
 
 Napi::Value TunDevice::GetName(const Napi::CallbackInfo& info) {
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
   return Napi::String::New(info.Env(), interface_name_);
 }
 
 Napi::Value TunDevice::GetFd(const Napi::CallbackInfo& info) {
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
   return Napi::Number::New(info.Env(), backend_ ? backend_->GetNativeFd() : -1);
 }
 
 Napi::Value TunDevice::GetForwardingHandle(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
 
   if (!is_open_ || !backend_ || !backend_->IsOpen()) {
     Napi::Error::New(env, "Device not open").ThrowAsJavaScriptException();
@@ -269,7 +275,7 @@ Napi::Value TunDevice::GetForwardingHandle(const Napi::CallbackInfo& info) {
 
 Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
 
   if (!is_open_ || !backend_ || !backend_->IsOpen()) {
     Napi::Error::New(env, "Device not open").ThrowAsJavaScriptException();
@@ -340,7 +346,7 @@ Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
   // ticks, so acquiring `device_mutex_` is safe.
   auto error_cb = [this](const std::string& message) {
     fprintf(stderr, "tuntap receive loop error: %s\n", message.c_str());
-    std::lock_guard<std::mutex> lock(device_mutex_);
+    std::scoped_lock lock(device_mutex_);
     polling_ = false;
     ReleaseTsfnLocked();
   };
@@ -358,7 +364,7 @@ Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
 
 Napi::Value TunDevice::PausePolling(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
 
   if (!polling_ || !backend_ || !backend_->IsOpen()) {
     return env.Undefined();
@@ -370,7 +376,7 @@ Napi::Value TunDevice::PausePolling(const Napi::CallbackInfo& info) {
 
 Napi::Value TunDevice::ResumePolling(const Napi::CallbackInfo& info) {
   Napi::Env env = info.Env();
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
 
   if (!polling_ || !backend_ || !backend_->IsOpen()) {
     return env.Undefined();
@@ -380,12 +386,20 @@ Napi::Value TunDevice::ResumePolling(const Napi::CallbackInfo& info) {
   return env.Undefined();
 }
 
+namespace {
+
 Napi::Object Init(Napi::Env env, Napi::Object exports) {
   TunDevice::Init(env, exports);
   InitTunnelForwarder(env, exports);
   return exports;
 }
 
+}  // namespace
+
+// __napi_Init, generated below by the macro, keeps 'static' linkage rather than
+// an anonymous namespace: it must stay reachable by name for NAPI_MODULE's
+// module-registration constructor in the same translation unit.
+// NOLINTNEXTLINE(misc-use-anonymous-namespace)
 NODE_API_MODULE(tuntap, Init)
 
 void TunDevice::CloseInternal() {
@@ -412,7 +426,7 @@ void TunDevice::ReleaseTsfnLocked() {
     poll_dispatch_->Detach();
     poll_dispatch_.reset();
   }
-  if (tsfn_) {
+  if (tsfn_ != nullptr) {
     tsfn_.Release();
     tsfn_ = nullptr;
   }
@@ -422,7 +436,7 @@ void TunPollDispatch::OnJsConsumed() {
   FlushPending();
   TunDevice* device = nullptr;
   {
-    std::lock_guard<std::mutex> lock(mutex);
+    std::scoped_lock lock(mutex);
     if (pending.empty() && device_ != nullptr) {
       device = device_;
     }
@@ -433,7 +447,7 @@ void TunPollDispatch::OnJsConsumed() {
 }
 
 void TunDevice::ResumeReceiveFromDispatch() {
-  std::lock_guard<std::mutex> lock(device_mutex_);
+  std::scoped_lock lock(device_mutex_);
   if (polling_ && backend_) {
     backend_->ResumeReceiveLoop();
   }


### PR DESCRIPTION
@harsha509 Could you please try this branch with a real device xpc stability test before merging it? I would like to make sure these warning fixes did not break anything