### PR TITLE
docs: fix inaccurate signal handling and debug flag claims

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,17 +57,28 @@ npm run build:addon; npm run test:unit
 src/
   tuntap.cc              # C++ Node-API surface (TunDevice class + module exports)
   native/
-    file_descriptor.h    # RAII file descriptor abstraction used by native backends
-    file_descriptor.cc   # FileDescriptor implementation
-    tun_backend.h        # TunPlatformBackend interface + OpenResult + shared declarations
-    tun_backend_common.cc# Backend factory + non-blocking fd helper
-    tun_backend_darwin.cc# macOS utun backend implementation
-    tun_backend_linux.cc # Linux /dev/net/tun backend implementation
+    file_descriptor.*    # RAII POSIX file descriptor wrapper
+    handle.*             # RAII Win32 HANDLE wrapper (mirrors FileDescriptor)
+    tun_backend.h        # TunPlatformBackend interface + shared declarations
+    posix_tun_backend.h  # Shared POSIX base (fd, interface name, poll loop)
+    posix_uv_poll_loop.* # uv_poll receive loop used by the POSIX backends
+    tun_backend_darwin.cc# macOS utun backend + CreatePlatformBackend()
+    tun_backend_linux.cc # Linux /dev/net/tun backend + CreatePlatformBackend()
+    tun_backend_windows.cc# WinTun backend + CreatePlatformBackend()
+    wintun_loader.*      # Resolves wintun.dll entry points at runtime
+    tunnel_forwarder.*   # TLS <-> TUN forwarding loops + N-API TunnelForwarder
+    tunnel_ssl.*         # OpenSSL client (lockdown cert or TLS-PSK)
+    ipv6_frame.h         # IPv6 frame length/reassembly helpers
+    debug_log.*          # APPIUM_TUNTAP_DEBUG `[fwd]` logging to stderr
+    win_delay_load_failure_hook.cc # Names the failing DLL/symbol on Windows delay-load errors
   index.ts               # Package entry: TunTap, PacketCallback, errors, tunnel/*
   TunTap.ts              # Wraps native TunDevice; validation; delegates OS networking to platform layer
+  pkg-root.ts            # Memoized package root for node-gyp-build
   tunnel/
-    manager.ts           # TunnelManager, connectToTunnelLockdown (native OpenSSL)
-    forwarder.ts         # TunnelForwarder TS wrapper
+    manager.ts           # TunnelManager, connectToTunnelLockdown, connectToTunnelPsk
+    forwarder.ts         # TunnelForwarder TS wrapper (+ Windows loopback bridge)
+    constants.ts         # CD_TUNNEL_MTU, IPv6 header constants
+    debug-log.ts         # APPIUM_TUNTAP_DEBUG + tunDebug
     types.ts             # TunnelConnection, TunnelInfo
   logger.ts              # @appium/support logger
   errors.ts              # TunTapError, TunTapPermissionError, TunTapDeviceError
@@ -76,12 +87,21 @@ src/
     create-platform.ts   # Internal: maps NodeJS.Platform → platform implementation (not public API)
     darwin.ts            # ifconfig, route, netstat (macOS)
     linux.ts             # iproute2 `ip` (Linux)
+    windows.ts           # netsh + PowerShell Get-NetAdapterStatistics
     unsupported.ts       # Stub that throws for unknown platforms
-    exec.ts              # promisify(execFile)
+    exec.ts              # execFile wrapper with a 30s timeout
     require-root.ts      # assertEffectiveRoot() — EUID 0 before privileged commands
+    require-admin.ts     # assertAdminOnWindows() — Administrator before privileged commands
+
+scripts/
+  fetch-wintun.mjs       # Maintainer-only: refresh vendor/wintun binaries
+  ci/lint-cpp.sh         # clang-tidy over host-OS native sources (npm run lint:cpp)
+
+vendor/wintun/           # Bundled signed wintun.dll per arch + upstream LICENSE
 
 test/
   unit/tuntap-unit.spec.ts
+  unit/tunnel/manager-forwarding.spec.ts
   integration/tuntap-integration.spec.ts
   test-tuntap.ts
   utils.ts
@@ -97,17 +117,18 @@ This is a Node.js native addon package that provides TUN/TAP virtual network dev
 A C++17 Node-API (NAPI) addon built via `node-gyp`. `src/tuntap.cc` is intentionally kept as the N-API interface/glue: it exposes `TunDevice` (`open()`, `close()`, `read()`, `write()`, `startPolling()`, `getName()`, `getFd()`), validates JS arguments, manages libuv polling (`uv_poll_t`), and bridges callbacks via `Napi::ThreadSafeFunction`.
 
 Native implementation details are split into `src/native/*`:
-- `TunPlatformBackend` interface in `tun_backend.h`
-- platform-specific backends in `tun_backend_darwin.cc` (utun) and `tun_backend_linux.cc` (`/dev/net/tun`)
-- shared utilities/factory in `tun_backend_common.cc`
-- `FileDescriptor` RAII abstraction in `file_descriptor.*`
+- `TunPlatformBackend` interface in `tun_backend.h`; each backend `.cc` defines its own `CreatePlatformBackend()`
+- platform-specific backends in `tun_backend_darwin.cc` (utun), `tun_backend_linux.cc` (`/dev/net/tun`), and `tun_backend_windows.cc` (WinTun via `wintun_loader.*`)
+- shared POSIX base + libuv receive loop in `posix_tun_backend.h` / `posix_uv_poll_loop.*`
+- RAII handles: `FileDescriptor` (POSIX) in `file_descriptor.*`, `Handle` (Win32) in `handle.*`
+- tunnel forwarding in `tunnel_forwarder.*` (TLS↔TUN loops, N-API `TunnelForwarder`) and `tunnel_ssl.*` (OpenSSL client for lockdown cert or TLS-PSK)
 
 ### TypeScript layer (`src/`)
 
 - **`errors.ts`** — shared error classes used by `TunTap` and `platform/*`.
 - **`TunTap.ts`** — loads the native addon via **`node-gyp-build`** (prebuilds or `build/Release`), validates IPv6/MTU/buffers, and calls a **`TunTapPlatform`** instance chosen by **`new TunTap(name?, platform?)`** where `platform` is a **`NodeJS.Platform`** string (default `process.platform`). No custom platform object is accepted at runtime; new OS support is wired in **`platform/create-platform.ts`**.
-- **`platform/*`** — OS-specific **`execFile`** usage for address, MTU, routes, and stats. Built-in Darwin/Linux paths require **effective UID 0** (**`assertEffectiveRoot`**); commands are run **without** embedding `sudo` in argv. **`getStats`** uses read-only tooling where possible without an extra root check.
-- **`tunnel/manager.ts`** — **`TunnelManager`**, native OpenSSL **`TunnelForwarder`**, and **`connectToTunnelLockdown`** (raw TCP + pair-record PEM).
+- **`platform/*`** — OS-specific **`execFile`** usage for address, MTU, routes, and stats, each call bounded by a **30s timeout** (`exec.ts`). Darwin/Linux require **effective UID 0** (**`assertEffectiveRoot`**) and Windows requires **Administrator** (**`assertAdminOnWindows`**); commands are run **without** embedding `sudo` in argv. **`getStats`** uses read-only tooling where possible without an extra privilege check.
+- **`tunnel/manager.ts`** — **`TunnelManager`**, native OpenSSL **`TunnelForwarder`**, **`connectToTunnelLockdown`** (raw TCP + pair-record PEM), and **`connectToTunnelPsk`** (TLS-PSK for Apple TV pairing).
 - **`logger.ts`** — thin wrapper around `@appium/support` logger.
 - **`index.ts`** — re-exports **`TunTap`**, **`PacketCallback`**, errors from **`errors.ts`**, and **`export *`** from **`tunnel/`**. Does **not** export the platform factory or concrete platform classes.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # TunTap Bridge
 
-A native TUN/TAP interface module for Node.js that works on macOS, Linux, and Windows, with enhanced error handling, signal management, and thread safety.
+A native TUN/TAP interface module for Node.js that works on macOS, Linux, and Windows, with enhanced error handling and thread safety.
 
 ## Description
 
@@ -10,9 +10,8 @@ This module provides a Node.js interface to TUN/TAP virtual network devices, all
 
 - **Cross-platform**: Works on macOS (utun), Linux (TUN/TAP), and Windows (WinTun)
 - **TypeScript support**: Full TypeScript definitions included
-- **Signal handling**: Graceful shutdown on SIGINT/SIGTERM
 - **Thread safety**: Safe to use from multiple Node.js worker threads
-- **Resource management**: Automatic cleanup of file descriptors and network interfaces
+- **Resource management**: Devices are closed on normal process exit; the kernel releases the fd otherwise
 - **Enhanced error handling**: Custom error types for better debugging
 - **Input validation**: Validates IPv6 addresses, MTU ranges, and buffer sizes
 - **Performance optimized**: Built with C++17 and compiler optimizations
@@ -183,21 +182,26 @@ await tunnel.closer();
 ### TunTap Class
 
 #### Constructor
-- `new TunTap(name?: string)` - Create a new TUN/TAP device instance
+- `new TunTap(name?: string, platform?: NodeJS.Platform)` - Create a new TUN/TAP device instance. `platform`
+  selects the OS backend used for addressing and routing, and defaults to `process.platform`.
 
 #### Methods
 - `open(): boolean` - Open the TUN device
 - `close(): boolean` - Close the TUN device
 - `read(maxSize?: number): Buffer` - Read data from the device (default: 4096 bytes)
 - `write(data: Buffer): number` - Write data to the device
+- `startPolling(callback, bufferSize?, queueDepth?): void` - Deliver each packet to `callback` (defaults: 65535 bytes, queue depth 8). One-shot: stop by closing the device.
+- `pausePolling(): void` / `resumePolling(): void` - Suspend and resume delivery without tearing down the callback
 - `configure(address: string, mtu?: number): Promise<void>` - Configure IPv6 address and MTU
 - `addRoute(destination: string): Promise<void>` - Add a route to the device
 - `removeRoute(destination: string): Promise<void>` - Remove a route from the device
-- `getStats(): Promise<Stats>` - Get interface statistics
+- `getStats(): Promise<Stats>` - Get interface statistics (`rxBytes`, `txBytes`, `rxPackets`, `txPackets`, `rxErrors`, `txErrors`)
 
 #### Properties
 - `name: string` - The device name (e.g., 'utun0', 'tun0')
 - `fd: number` - The native file descriptor on POSIX (macOS/Linux). Returns `-1` on Windows; Wintun does not expose a numeric file descriptor.
+- `isOpen: boolean` - `open()` has succeeded and `close()` has not run
+- `isClosed: boolean` - `close()` has been called; the device cannot be reopened
 
 ### Error Types
 
@@ -207,7 +211,20 @@ await tunnel.closer();
 
 ### Signal Handling
 
-The module automatically handles SIGINT and SIGTERM signals for graceful shutdown. All open devices will be closed and network interfaces cleaned up when the process exits.
+The module does **not** install `SIGINT`/`SIGTERM` handlers — a library should not take over signals from the
+application that embeds it. It registers a `process.once('exit')` hook that closes any open device on a normal
+exit.
+
+`exit` handlers do not run when a process is terminated by a signal, so on Ctrl+C the device is not closed by
+this module; the kernel releases the file descriptor and tears down the interface when the process dies. If you
+need cleanup to run on a signal, install your own handler and call `close()`:
+
+```javascript
+process.once('SIGINT', () => {
+  tun.close();
+  process.exit(130);
+});
+```
 
 ## Troubleshooting
 
@@ -235,10 +252,11 @@ The module automatically handles SIGINT and SIGTERM signals for graceful shutdow
 
 ## Debug Mode
 
-Enable debug logging by running your application with the `--debug` flag:
+Set `APPIUM_TUNTAP_DEBUG=1` to enable tunnel debug logging. The TypeScript layer logs through
+`@appium/support`; the native forwarder writes `[fwd] #N event key=value` lines to stderr.
 
 ```bash
-node your-app.js --debug
+APPIUM_TUNTAP_DEBUG=1 node your-app.js
 ```
 
 ## Testing
@@ -274,22 +292,18 @@ If you are **not** running as root, you will see a message that tests are skippe
 
 Windows tunnel-forwarder end-to-end testing requires a real device tunnel source. From an elevated PowerShell, build the addon, run the unit tests, then establish a CoreDevice/RemoteXPC tunnel and verify the forwarded tunnel remains stable under AFC or similar traffic.
 
-### Manual Testing for Signal Handling (v0.0.4+)
-
-Automated tests cannot reliably verify process cleanup on SIGINT/SIGTERM due to test runner limitations.  
-To manually verify the fix for signal handling (introduced in v0.0.4):
+### Manual Testing for Device Cleanup
 
 1. Build the project, then run the compiled CLI utility:
    ```sh
    npm run build
    sudo node lib/test/test-tuntap.js
    ```
-2. While it is running, press `Ctrl+C` to send SIGINT.
-3. Confirm that:
-   - The process exits immediately.
-   - All TUN/TAP devices are closed and cleaned up.
+2. While it is running, press `Ctrl+C`.
+3. Confirm the process exits and the interface is gone (`ifconfig` on macOS, `ip link` on Linux).
 
-This ensures the signal handler works as intended.
+The interface disappears because the kernel closes the file descriptor when the process dies, not because
+the module handled the signal — see [Signal Handling](#signal-handling).
 
 ## License
 


### PR DESCRIPTION
Docs update. The README claimed SIGINT/SIGTERM handling and a `--debug` flag that don't exist, and the API reference and CLAUDE.md structure were out of date.