### PR TITLE
chore: clean up forwarder and typing nits

### DIFF
--- a/src/TunTap.ts
+++ b/src/TunTap.ts
@@ -45,7 +45,7 @@ const nativeTuntap = require('node-gyp-build')(getPkgRoot()) as NativeTuntapModu
  * Routing and addressing use a built-in OS backend chosen from the `platform` argument (requires root, EUID 0 on Darwin/Linux).
  */
 export class TunTap {
-  private device: NativeTunDevice;
+  private readonly device: NativeTunDevice;
   private readonly platformBackend: TunTapPlatform;
   private _isOpen: boolean;
   private _isClosed: boolean;
@@ -208,11 +208,7 @@ export class TunTap {
     }
 
     try {
-      const result = this.device.write(data);
-      if (result < 0) {
-        throw new TunTapError('Write operation failed');
-      }
-      return result;
+      return this.device.write(data);
     } catch (err: unknown) {
       throw new TunTapError(`Write failed: ${(err as Error).message}`);
     }
@@ -223,6 +219,7 @@ export class TunTap {
    *
    * @param callback — invoked with each packet read from the device
    * @param bufferSize — max read size per poll (default 65535)
+   * @param queueDepth — packets the native layer may queue ahead of the callback (1–64, default 8)
    * @throws {TunTapError} if not open or closed
    * @throws {TypeError} if `callback` is not a function
    * @throws {RangeError} if `bufferSize` is out of range

--- a/src/tunnel/forwarder.ts
+++ b/src/tunnel/forwarder.ts
@@ -7,6 +7,7 @@ import type {TunTap} from '../TunTap.js';
 import type {TunnelInfo} from './types.js';
 
 const require = createRequire(import.meta.url);
+const nativeTuntap = require('node-gyp-build')(getPkgRoot()) as NativeTuntapModule;
 
 /** PEM host certificate + private key from the usbmux pair record (lockdown TLS). */
 export interface TunnelLockdownTlsCredentials {
@@ -44,8 +45,7 @@ export class TunnelForwarder {
   private loopbackBridge: Server | null = null;
 
   async connect(tcpSocket: Socket, credentials: TunnelLockdownTlsCredentials): Promise<void> {
-    const native = require('node-gyp-build')(getPkgRoot()) as NativeTuntapModule;
-    this.forwarder = new native.TunnelForwarder();
+    this.forwarder = new nativeTuntap.TunnelForwarder();
 
     if (process.platform === 'win32') {
       const {host, port} = await this.bridgeToNative(tcpSocket);
@@ -54,13 +54,13 @@ export class TunnelForwarder {
       tcpSocket.pause();
       tcpSocket.removeAllListeners();
       this.forwarder.connect(getSocketFd(tcpSocket), credentials.cert, credentials.key);
-      this.takeSocketOwnership(tcpSocket);
+      // Native holds its own dup() of the fd, so drop the JS socket.
+      destroySocket(tcpSocket);
     }
   }
 
   async connectPsk(tcpSocket: Socket, credentials: TunnelPskTlsCredentials): Promise<void> {
-    const native = require('node-gyp-build')(getPkgRoot()) as NativeTuntapModule;
-    this.forwarder = new native.TunnelForwarder();
+    this.forwarder = new nativeTuntap.TunnelForwarder();
 
     if (process.platform === 'win32') {
       const {host, port} = await this.bridgeToNative(tcpSocket);
@@ -69,7 +69,8 @@ export class TunnelForwarder {
       tcpSocket.pause();
       tcpSocket.removeAllListeners();
       this.forwarder.connectPsk(getSocketFd(tcpSocket), credentials.psk, credentials.identity ?? '');
-      this.takeSocketOwnership(tcpSocket);
+      // Native holds its own dup() of the fd, so drop the JS socket.
+      destroySocket(tcpSocket);
     }
   }
 
@@ -105,10 +106,6 @@ export class TunnelForwarder {
       destroySocket(this.retainedSocket);
       this.retainedSocket = null;
     }
-  }
-
-  private takeSocketOwnership(socket: Socket): void {
-    destroySocket(socket);
   }
 
   /**

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -47,8 +47,8 @@ export class TunnelManager {
         mtu: tunnelInfo.clientParameters.mtu,
         interface: this.tun,
       };
-    } catch (err: any) {
-      log.error(`Error setting up TUN interface: ${err.message}`);
+    } catch (err: unknown) {
+      log.error(`Error setting up TUN interface: ${(err as Error).message}`);
       if (this.tun) {
         try {
           this.tun.close();
@@ -189,7 +189,7 @@ async function connectTunnel(
       tunnelManager,
       closer: closeFunc,
     };
-  } catch (err: any) {
+  } catch (err: unknown) {
     log.error('Failed to connect to tunnel:', err);
     forwarder.stop();
     await tunnelManager.stop();


### PR DESCRIPTION
Loads the addon once instead of on every connect, drops `takeSocketOwnership` (it only destroyed the socket), and fixes `catch (err: any)`, a dead branch in `write()`, and a missing JSDoc param.

No behaviour change.