### PR TITLE
fix: release TSFN after polling and stop caching admin check failures

### DIFF
--- a/src/platform/require-admin.ts
+++ b/src/platform/require-admin.ts
@@ -1,5 +1,3 @@
-import {util} from '@appium/support';
-
 import {TunTapPermissionError} from '../errors.js';
 import {execFileAsync} from './exec.js';
 
@@ -18,19 +16,25 @@ export async function assertAdminOnWindows(): Promise<void> {
   );
 }
 
+let confirmedAdmin = false;
+
 /**
  * Returns true when the current process is running with Administrator
- * privileges on Windows. Implementation runs `net session` (which always
- * exists, regardless of locale) and inspects the exit code.
+ * privileges on Windows, probed via `net session` exit code.
  *
- * The result is memoized for the lifetime of the process; admin status cannot
- * change between calls without restarting the shell.
+ * Only success is cached: `net session` can fail transiently (spawn error,
+ * 30s timeout) or permanently on Server-service-disabled machines, so a
+ * failure is never cached and the next call re-probes.
  */
-export const isAdministrator = util.memoize(async function isAdministratorUncached(): Promise<boolean> {
+export async function isAdministrator(): Promise<boolean> {
+  if (confirmedAdmin) {
+    return true;
+  }
   try {
     await execFileAsync('net', ['session'], {windowsHide: true});
+    confirmedAdmin = true;
     return true;
   } catch {
     return false;
   }
-});
+}

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -57,17 +57,19 @@ struct TunPollDispatch : public std::enable_shared_from_this<TunPollDispatch> {
     std::scoped_lock lock(mutex);
     while (!pending.empty()) {
       auto* packet = new std::vector<uint8_t>(std::move(pending.front()));
+      pending.pop_front();
       auto* job = new PacketJob{shared_from_this(), packet};
       napi_status status = tsfn.NonBlockingCall(job, [](Napi::Env env, Napi::Function jsCallback, PacketJob* job) {
         CallJs(env, jsCallback, job->dispatch, job->packet);
         delete job;
       });
       if (status != napi_ok) {
+        // Queue full or TSFN closing: requeue so data and order survive.
+        pending.push_front(std::move(*packet));
         delete packet;
         delete job;
         break;
       }
-      pending.pop_front();
     }
   }
 
@@ -311,7 +313,9 @@ Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {
 
   // Queue depth > 1 lets the poll thread post the next packet while JS is still
   // handling the previous callback (still serialized on the main thread).
-  tsfn_ = Napi::ThreadSafeFunction::New(env, info[0].As<Napi::Function>(), "TunDeviceDataCallback", 0, queue_depth);
+  // Bounded queue (queue_depth) + one thread ref so the single Release() in
+  // ReleaseTsfnLocked finalizes the TSFN and unpins the event loop.
+  tsfn_ = Napi::ThreadSafeFunction::New(env, info[0].As<Napi::Function>(), "TunDeviceDataCallback", queue_depth, 1);
 
   uv_loop_t* loop = nullptr;
   napi_status napi_st = napi_get_uv_event_loop(env, &loop);

--- a/test/unit/tuntap-unit.spec.ts
+++ b/test/unit/tuntap-unit.spec.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert';
+import {spawn} from 'node:child_process';
 import {afterEach, describe, it} from 'node:test';
 
 import {TunTap, TunnelForwarder} from '../../src/index.js';
@@ -80,6 +81,41 @@ describe('TunTap Unit Tests', {timeout: 10000}, () => {
     );
     assert.ok(handles.length <= 2, 'No extra handles should remain after close');
   });
+
+  // Regression: a leaked TSFN thread ref after startPolling() kept the uv loop
+  // pinned, so a process that opened, polled, and closed never exited.
+  it(
+    'should exit naturally after startPolling then close',
+    {skip: process.platform === 'win32' ? 'POSIX-only regression check' : skipWithoutPrivileges},
+    async () => {
+      const indexUrl = new URL('../../src/index.js', import.meta.url).href;
+      const script = [
+        `const {TunTap} = await import(${JSON.stringify(indexUrl)});`,
+        'const tun = new TunTap();',
+        'tun.open();',
+        'tun.startPolling(() => {});',
+        'tun.close();',
+      ].join('\n');
+      const child = spawn(process.execPath, ['--input-type=module', '-e', script], {
+        stdio: ['ignore', 'ignore', 'inherit'],
+      });
+      const exitCode = await new Promise<number | null>((resolve, reject) => {
+        const timer = setTimeout(() => {
+          child.kill('SIGKILL');
+          reject(new Error('Child did not exit within 5s: event loop still pinned after startPolling/close'));
+        }, 5000);
+        child.once('exit', (code) => {
+          clearTimeout(timer);
+          resolve(code);
+        });
+        child.once('error', (err) => {
+          clearTimeout(timer);
+          reject(err);
+        });
+      });
+      assert.strictEqual(exitCode, 0, 'child should exit cleanly');
+    },
+  );
 
   it('should handle errors gracefully', {skip: skipWithoutPrivileges}, async () => {
     tun = new TunTap();


### PR DESCRIPTION
## Issue
- startPolling created the TSFN with an unlimited queue and 8 thread refs. The single Release never finalized it so the event loop stayed pinned forever after close.
- FlushPending deleted the packet when NonBlockingCall failed and left an empty entry in the queue. Data lost and a zero length buffer re-posted later.
- isAdministrator cached failures. One transient net session error broke every later privileged call in the process.

## Fix
- Pass (queue_depth, 1) to ThreadSafeFunction::New. Bounded queue and one thread ref matching the one release.
- FlushPending pops the packet first and puts it back on failure. Order and data survive.
- Cache the admin check only on success. Failures re-probe on the next call.
- New regression test spawns a child that does open, startPolling, close and must exit on its own within 5s.