### PR TITLE
fix: share TUN backend ownership between device and forwarder

### DIFF
--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -417,7 +417,7 @@ bool TunnelForwarder::Handshake(uint32_t requested_mtu, TunnelHandshakeInfo& inf
   return true;
 }
 
-bool TunnelForwarder::StartForwarding(TunPlatformBackend* tun_backend, ForwarderErrorCallback on_error,
+bool TunnelForwarder::StartForwarding(std::shared_ptr<TunPlatformBackend> tun_backend, ForwarderErrorCallback on_error,
                                       std::string& error) {
   if (running_.load()) {
     error = "Tunnel forwarder already running";
@@ -427,7 +427,7 @@ bool TunnelForwarder::StartForwarding(TunPlatformBackend* tun_backend, Forwarder
     error = "TLS session is not connected";
     return false;
   }
-  if (tun_backend == nullptr || !tun_backend->IsOpen()) {
+  if (!tun_backend || !tun_backend->IsOpen()) {
     error = "TUN device is not open";
     return false;
   }
@@ -445,12 +445,12 @@ bool TunnelForwarder::StartForwarding(TunPlatformBackend* tun_backend, Forwarder
     on_error_ = std::move(on_error);
   }
 
-  tun_backend_ = tun_backend;
+  tun_backend_ = std::move(tun_backend);
   running_.store(true);
   tun_writes_.store(0);
   tun_drops_.store(0);
   ssl_reads_.store(0);
-  tuntap::FwdDebug("forwarder-start", "mtu=%zu tunFd=%d", mtu_, tun_backend->GetNativeFd());
+  tuntap::FwdDebug("forwarder-start", "mtu=%zu tunFd=%d", mtu_, tun_backend_->GetNativeFd());
   tun_thread_ = std::thread(&TunnelForwarder::TunToDeviceLoop, this);
   sock_thread_ = std::thread(&TunnelForwarder::DeviceToTunLoop, this);
   return true;
@@ -479,7 +479,8 @@ void TunnelForwarder::Stop() {
   }
 
   ssl_.Close();
-  tun_backend_ = nullptr;
+  // Reset only after joining both threads: drops this forwarder's strong ref.
+  tun_backend_.reset();
 }
 
 ssize_t TunnelForwarder::SslReadChunk(uint8_t* buf, size_t max_len, bool only_while_running) {
@@ -1071,10 +1072,15 @@ class TunnelForwarderWrap : public Napi::ObjectWrap<TunnelForwarderWrap> {
       error_tsfn_ = Napi::ThreadSafeFunction::New(env, on_error, "TunnelForwarderOnError", 0, 1);
     }
 
-    TunPlatformBackend* tun_backend = info[0].As<Napi::External<TunPlatformBackend>>().Data();
+    auto* tun_backend = info[0].As<Napi::External<std::shared_ptr<TunPlatformBackend>>>().Data();
+    if (tun_backend == nullptr) {
+      ReleaseErrorTsfn();
+      Napi::Error::New(env, "TUN device is not open").ThrowAsJavaScriptException();
+      return env.Undefined();
+    }
     std::string error;
     ForwarderErrorCallback callback = [this](std::string msg) { ReportError(std::move(msg)); };
-    if (!forwarder_.StartForwarding(tun_backend, std::move(callback), error)) {
+    if (!forwarder_.StartForwarding(*tun_backend, std::move(callback), error)) {
       ReleaseErrorTsfn();
       Napi::Error::New(env, error).ThrowAsJavaScriptException();
     }

--- a/src/native/tunnel_forwarder.h
+++ b/src/native/tunnel_forwarder.h
@@ -4,6 +4,7 @@
 #include <chrono>
 #include <cstdint>
 #include <functional>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <thread>
@@ -47,7 +48,8 @@ class TunnelForwarder {
 
   bool Handshake(uint32_t requested_mtu, TunnelHandshakeInfo& info, std::string& error);
 
-  bool StartForwarding(TunPlatformBackend* tun_backend, ForwarderErrorCallback on_error, std::string& error);
+  bool StartForwarding(std::shared_ptr<TunPlatformBackend> tun_backend, ForwarderErrorCallback on_error,
+                       std::string& error);
 
   void Stop();
 
@@ -66,7 +68,7 @@ class TunnelForwarder {
   std::mutex error_mutex_;
   ForwarderErrorCallback on_error_;
   std::atomic<bool> error_reported_{false};
-  TunPlatformBackend* tun_backend_ = nullptr;
+  std::shared_ptr<TunPlatformBackend> tun_backend_;
   size_t mtu_ = 1280;
   std::atomic<bool> running_{false};
   std::atomic<uint64_t> tun_writes_{0};

--- a/src/tuntap.cc
+++ b/src/tuntap.cc
@@ -112,7 +112,7 @@ class TunDevice : public Napi::ObjectWrap<TunDevice> {
   Napi::Value PausePolling(const Napi::CallbackInfo& info);
   Napi::Value ResumePolling(const Napi::CallbackInfo& info);
 
-  std::unique_ptr<TunPlatformBackend> backend_;
+  std::shared_ptr<TunPlatformBackend> backend_;
   std::string requested_name_;
   std::string interface_name_;
   std::atomic<bool> is_open_;
@@ -272,7 +272,11 @@ Napi::Value TunDevice::GetForwardingHandle(const Napi::CallbackInfo& info) {
     return env.Null();
   }
 
-  return Napi::External<TunPlatformBackend>::New(env, backend_.get());
+  // The External owns a strong ref: the backend stays alive for forwarding
+  // threads even if this TunDevice is GC'd first.
+  auto* shared = new std::shared_ptr<TunPlatformBackend>(backend_);
+  return Napi::External<std::shared_ptr<TunPlatformBackend>>::New(
+      env, shared, [](Napi::Env, std::shared_ptr<TunPlatformBackend>* data) { delete data; });
 }
 
 Napi::Value TunDevice::StartPolling(const Napi::CallbackInfo& info) {


### PR DESCRIPTION
## Issue
getForwardingHandle gave the forwarder a raw pointer into the unique_ptr owned by TunDevice. If the TunTap object got GCd while forwarding was running the backend was freed under the forwarder threads. Use after free. Only the stop ordering in TunnelManager kept it safe.

## Fix
- TunDevice holds the backend in a shared_ptr
- The forwarding handle is an External owning a strong ref, finalizer releases it
- Forwarder stores a shared_ptr and drops it in Stop after joining both threads
- tun.close() still closes the fd right away so the loops fail gracefully as before

No TS or public API change. Native only.