### PR TITLE
feat: allow requesting a larger tunnel MTU via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,20 @@ process.once('SIGINT', () => {
 });
 ```
 
+## Verifying AFC data-path changes
+
+Any change touching the forwarding path (native forwarder, backends, tunnel MTU, TLS) must be verified against a real device with the AFC tests in [appium-ios-remotexpc](https://github.com/appium/appium-ios-remotexpc). With a live tunnel up (`npm run tunnel-creation`):
+
+```sh
+# Throughput: pushes a 10 MiB file over AFC, reports MiB/s
+npm run test:afc-push-perf
+
+# Stability: 20 rounds of 10 MiB push + pull + sha256 verify over one AFC session
+AFC_STABILITY_ITERATIONS=20 npm run test:afc-tunnel-stability
+```
+
+Both must pass, and push throughput should be flat or better versus a run on the unchanged build. Compare only runs on the same link: USB and Wi-Fi tunnels differ by an order of magnitude (check the `Connection:` type logged by tunnel-creation).
+
 ## Troubleshooting
 
 ### Linux Issues

--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ process.once('SIGINT', () => {
 });
 ```
 
+## Environment Variables
+
+### APPIUM_TUNTAP_MTU_REQUEST_SIZE
+
+MTU to request from the device in the CDTunnel handshake. Defaults to `1280` (the IPv6 minimum). Accepts integers in `1280`–`65000`; out-of-range values are clamped and invalid values fall back to the default with a warning. The device decides the granted value, which is what actually gets applied — the tunnel log shows `requested X, granted Y`.
+
+Note: a device may grant a value it cannot reliably carry (observed: a grant of 16000 where packets above ~8 KB were silently dropped, breaking AFC). Validate any non-default value with the AFC tests below before adopting it.
+
 ## Verifying AFC data-path changes
 
 Any change touching the forwarding path (native forwarder, backends, tunnel MTU, TLS) must be verified against a real device with the AFC tests in [appium-ios-remotexpc](https://github.com/appium/appium-ios-remotexpc). With a live tunnel up (`npm run tunnel-creation`):

--- a/src/tunnel/constants.ts
+++ b/src/tunnel/constants.ts
@@ -1,5 +1,28 @@
+import {log} from '../logger.js';
+
 /** CDTunnel lockdown handshake MTU (IPv6 minimum). */
 export const CD_TUNNEL_MTU = 1280;
 
+/** Upper bound for MTU requests (WinTun per-packet cap is 65535; keep margin). */
+export const MAX_TUNNEL_MTU_REQUEST = 65000;
+
 export const IPV6_HEADER_SIZE = 40;
 export const IPV6_VERSION = 6;
+
+/**
+ * MTU to request in the CDTunnel handshake, from APPIUM_TUNTAP_MTU_REQUEST.
+ * Clamped to [CD_TUNNEL_MTU, MAX_TUNNEL_MTU_REQUEST]; unset or invalid falls
+ * back to CD_TUNNEL_MTU. The device may grant less than requested.
+ */
+export function getRequestedTunnelMtu(): number {
+  const raw = process.env.APPIUM_TUNTAP_MTU_REQUEST?.trim();
+  if (!raw) {
+    return CD_TUNNEL_MTU;
+  }
+  const parsed = Number(raw);
+  if (!Number.isInteger(parsed)) {
+    log.warn(`Ignoring invalid APPIUM_TUNTAP_MTU_REQUEST '${raw}'; using default MTU ${CD_TUNNEL_MTU}`);
+    return CD_TUNNEL_MTU;
+  }
+  return Math.min(Math.max(parsed, CD_TUNNEL_MTU), MAX_TUNNEL_MTU_REQUEST);
+}

--- a/src/tunnel/constants.ts
+++ b/src/tunnel/constants.ts
@@ -1,28 +1,30 @@
 import {log} from '../logger.js';
 
 /** CDTunnel lockdown handshake MTU (IPv6 minimum). */
-export const CD_TUNNEL_MTU = 1280;
+export const CD_TUNNEL_MTU_SIZE = 1280;
 
 /** Upper bound for MTU requests (WinTun per-packet cap is 65535; keep margin). */
-export const MAX_TUNNEL_MTU_REQUEST = 65000;
+export const MAX_TUNNEL_MTU_REQUEST_SIZE = 65000;
 
 export const IPV6_HEADER_SIZE = 40;
 export const IPV6_VERSION = 6;
 
 /**
- * MTU to request in the CDTunnel handshake, from APPIUM_TUNTAP_MTU_REQUEST.
- * Clamped to [CD_TUNNEL_MTU, MAX_TUNNEL_MTU_REQUEST]; unset or invalid falls
- * back to CD_TUNNEL_MTU. The device may grant less than requested.
+ * MTU to request in the CDTunnel handshake, from APPIUM_TUNTAP_MTU_REQUEST_SIZE.
+ * Clamped to [CD_TUNNEL_MTU_SIZE, MAX_TUNNEL_MTU_REQUEST_SIZE]; unset or invalid
+ * falls back to CD_TUNNEL_MTU_SIZE. The device may grant less than requested.
+ * Not memoized on purpose: it runs once per tunnel creation and callers may
+ * change the env between tunnels (and tests between cases).
  */
 export function getRequestedTunnelMtu(): number {
-  const raw = process.env.APPIUM_TUNTAP_MTU_REQUEST?.trim();
+  const raw = process.env.APPIUM_TUNTAP_MTU_REQUEST_SIZE?.trim();
   if (!raw) {
-    return CD_TUNNEL_MTU;
+    return CD_TUNNEL_MTU_SIZE;
   }
   const parsed = Number(raw);
   if (!Number.isInteger(parsed)) {
-    log.warn(`Ignoring invalid APPIUM_TUNTAP_MTU_REQUEST '${raw}'; using default MTU ${CD_TUNNEL_MTU}`);
-    return CD_TUNNEL_MTU;
+    log.warn(`Ignoring invalid APPIUM_TUNTAP_MTU_REQUEST_SIZE '${raw}'; using default MTU ${CD_TUNNEL_MTU_SIZE}`);
+    return CD_TUNNEL_MTU_SIZE;
   }
-  return Math.min(Math.max(parsed, CD_TUNNEL_MTU), MAX_TUNNEL_MTU_REQUEST);
+  return Math.min(Math.max(parsed, CD_TUNNEL_MTU_SIZE), MAX_TUNNEL_MTU_REQUEST_SIZE);
 }

--- a/src/tunnel/manager.ts
+++ b/src/tunnel/manager.ts
@@ -2,7 +2,7 @@ import type {Socket} from 'node:net';
 
 import {log} from '../logger.js';
 import {TunTap} from '../TunTap.js';
-import {CD_TUNNEL_MTU} from './constants.js';
+import {getRequestedTunnelMtu} from './constants.js';
 import {tunDebug} from './debug-log.js';
 import {TunnelForwarder, type TunnelLockdownTlsCredentials, type TunnelPskTlsCredentials} from './forwarder.js';
 import type {TunnelConnection, TunnelInfo} from './types.js';
@@ -170,7 +170,9 @@ async function connectTunnel(
     tcpSocket.setKeepAlive(true, 1000);
 
     await setupTls(forwarder);
-    const tunnelInfo = await forwarder.handshake(CD_TUNNEL_MTU);
+    const requestedMtu = getRequestedTunnelMtu();
+    const tunnelInfo = await forwarder.handshake(requestedMtu);
+    log.info(`Tunnel MTU: requested ${requestedMtu}, granted ${tunnelInfo.clientParameters.mtu}`);
     tunDebug('Tunnel parameters exchanged:', tunnelInfo);
 
     const tunInterfaceInfo = await tunnelManager.setupInterface(tunnelInfo);

--- a/test/unit/tunnel/constants.spec.ts
+++ b/test/unit/tunnel/constants.spec.ts
@@ -1,37 +1,32 @@
 import assert from 'node:assert';
 import {afterEach, describe, it} from 'node:test';
 
-import {CD_TUNNEL_MTU, MAX_TUNNEL_MTU_REQUEST, getRequestedTunnelMtu} from '../../../src/tunnel/constants.js';
+import {CD_TUNNEL_MTU_SIZE, MAX_TUNNEL_MTU_REQUEST_SIZE, getRequestedTunnelMtu} from '../../../src/tunnel/constants.js';
 
 describe('getRequestedTunnelMtu', () => {
   afterEach(() => {
-    delete process.env.APPIUM_TUNTAP_MTU_REQUEST;
+    delete process.env.APPIUM_TUNTAP_MTU_REQUEST_SIZE;
   });
 
-  it('returns the default when unset', () => {
-    delete process.env.APPIUM_TUNTAP_MTU_REQUEST;
-    assert.strictEqual(getRequestedTunnelMtu(), CD_TUNNEL_MTU);
-  });
+  const cases: {name: string; value: string | undefined; expected: number}[] = [
+    {name: 'unset returns the default', value: undefined, expected: CD_TUNNEL_MTU_SIZE},
+    {name: 'valid value is used', value: '16000', expected: 16000},
+    {name: 'below IPv6 minimum clamps up', value: '500', expected: CD_TUNNEL_MTU_SIZE},
+    {name: 'above maximum clamps down', value: '70000', expected: MAX_TUNNEL_MTU_REQUEST_SIZE},
+    {name: 'non-numeric falls back', value: 'abc', expected: CD_TUNNEL_MTU_SIZE},
+    {name: 'non-integer falls back', value: '12.5', expected: CD_TUNNEL_MTU_SIZE},
+    {name: 'trailing garbage falls back', value: '1280x', expected: CD_TUNNEL_MTU_SIZE},
+    {name: 'blank falls back', value: ' ', expected: CD_TUNNEL_MTU_SIZE},
+  ];
 
-  it('returns a valid requested value', () => {
-    process.env.APPIUM_TUNTAP_MTU_REQUEST = '16000';
-    assert.strictEqual(getRequestedTunnelMtu(), 16000);
-  });
-
-  it('clamps values below the IPv6 minimum', () => {
-    process.env.APPIUM_TUNTAP_MTU_REQUEST = '500';
-    assert.strictEqual(getRequestedTunnelMtu(), CD_TUNNEL_MTU);
-  });
-
-  it('clamps values above the maximum', () => {
-    process.env.APPIUM_TUNTAP_MTU_REQUEST = '70000';
-    assert.strictEqual(getRequestedTunnelMtu(), MAX_TUNNEL_MTU_REQUEST);
-  });
-
-  it('falls back to the default on non-integer input', () => {
-    for (const value of ['abc', '12.5', '1280x', ' ']) {
-      process.env.APPIUM_TUNTAP_MTU_REQUEST = value;
-      assert.strictEqual(getRequestedTunnelMtu(), CD_TUNNEL_MTU, `input '${value}'`);
-    }
-  });
+  for (const {name, value, expected} of cases) {
+    it(name, () => {
+      if (value === undefined) {
+        delete process.env.APPIUM_TUNTAP_MTU_REQUEST_SIZE;
+      } else {
+        process.env.APPIUM_TUNTAP_MTU_REQUEST_SIZE = value;
+      }
+      assert.strictEqual(getRequestedTunnelMtu(), expected);
+    });
+  }
 });

--- a/test/unit/tunnel/constants.spec.ts
+++ b/test/unit/tunnel/constants.spec.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert';
+import {afterEach, describe, it} from 'node:test';
+
+import {CD_TUNNEL_MTU, MAX_TUNNEL_MTU_REQUEST, getRequestedTunnelMtu} from '../../../src/tunnel/constants.js';
+
+describe('getRequestedTunnelMtu', () => {
+  afterEach(() => {
+    delete process.env.APPIUM_TUNTAP_MTU_REQUEST;
+  });
+
+  it('returns the default when unset', () => {
+    delete process.env.APPIUM_TUNTAP_MTU_REQUEST;
+    assert.strictEqual(getRequestedTunnelMtu(), CD_TUNNEL_MTU);
+  });
+
+  it('returns a valid requested value', () => {
+    process.env.APPIUM_TUNTAP_MTU_REQUEST = '16000';
+    assert.strictEqual(getRequestedTunnelMtu(), 16000);
+  });
+
+  it('clamps values below the IPv6 minimum', () => {
+    process.env.APPIUM_TUNTAP_MTU_REQUEST = '500';
+    assert.strictEqual(getRequestedTunnelMtu(), CD_TUNNEL_MTU);
+  });
+
+  it('clamps values above the maximum', () => {
+    process.env.APPIUM_TUNTAP_MTU_REQUEST = '70000';
+    assert.strictEqual(getRequestedTunnelMtu(), MAX_TUNNEL_MTU_REQUEST);
+  });
+
+  it('falls back to the default on non-integer input', () => {
+    for (const value of ['abc', '12.5', '1280x', ' ']) {
+      process.env.APPIUM_TUNTAP_MTU_REQUEST = value;
+      assert.strictEqual(getRequestedTunnelMtu(), CD_TUNNEL_MTU, `input '${value}'`);
+    }
+  });
+});


### PR DESCRIPTION
## Issue
The CDTunnel handshake always requests MTU 1280, the IPv6 minimum. Bulk AFC transfers pay per packet overhead so a small MTU means thousands of packets, TLS records and lock acquisitions per chunk.

## Fix
- New env var APPIUM_TUNTAP_MTU_REQUEST sets the requested MTU, clamped to 1280 to 65000, invalid input warns and falls back
- Default stays 1280 so nothing changes unless the env var is set
- The device granted value is applied as before, we only change the ask
- Requested vs granted MTU now logged at info level
- README section on running the AFC tests after data path changes
- Unit tests for the env parsing

TS only, no native change.