### PR TITLE
perf: coalesce queued TUN packets into single SSL writes

### DIFF
--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -700,6 +700,48 @@ void TunnelForwarder::AppendTunPacket(std::vector<uint8_t>& batch, std::vector<u
   }
 }
 
+// Coalesces packets already queued on the TUN fd into the batch without
+// waiting. ReadPacket is used directly: ReadTunPacket turns NoData into a
+// wait. Stops while a worst-case packet still fits so one SSL write stays a
+// single TLS record. Returns false when the backend reported Closed or Error.
+bool TunnelForwarder::DrainQueuedTunPackets(std::vector<uint8_t>& batch, std::vector<uint8_t>& packet) {
+  while (batch.size() + mtu_ <= kTunBatchMax) {
+    std::string error;
+    const ReadPacketStatus status = tun_backend_->ReadPacket(mtu_, packet, error);
+    if (status == ReadPacketStatus::NoData) {
+      break;
+    }
+    if (status == ReadPacketStatus::Data) {
+      if (!packet.empty()) {
+        AppendTunPacket(batch, packet);
+      }
+      continue;
+    }
+    if (status == ReadPacketStatus::Error && !error.empty()) {
+      tuntap::FwdDebug("forwarder-tun-read-error", "%s", error.c_str());
+    }
+    return false;
+  }
+  return true;
+}
+
+// Sends the whole batch with one SSL write. Returns false on write failure.
+bool TunnelForwarder::FlushTunBatch(const std::vector<uint8_t>& batch, uint64_t writes_before, uint64_t& batches) {
+  if (batch.empty()) {
+    return true;
+  }
+  if (SslWriteAll(batch.data(), batch.size()) < 0) {
+    return false;
+  }
+  ++batches;
+  if (batches <= 100 || batches % 200 == 0) {
+    tuntap::FwdDebug("forwarder-tun-batch", "packets=%llu bytes=%zu batches=%llu",
+                     static_cast<unsigned long long>(tun_writes_.load() - writes_before), batch.size(),
+                     static_cast<unsigned long long>(batches));
+  }
+  return true;
+}
+
 void TunnelForwarder::TunToDeviceLoop() {
   std::vector<uint8_t> packet;
   std::vector<uint8_t> batch;
@@ -721,47 +763,16 @@ void TunnelForwarder::TunToDeviceLoop() {
     batch.clear();
     const uint64_t writes_before = tun_writes_.load();
     AppendTunPacket(batch, packet);
+    // Drain failure still flushes the batch first so drained packets survive.
+    const bool drain_ok = DrainQueuedTunPackets(batch, packet);
 
-    // Coalesce packets already queued on the TUN fd into one SSL write.
-    // ReadPacket is used directly: ReadTunPacket turns NoData into a wait.
-    // Stop while a worst-case packet still fits so the write stays one record.
-    bool read_failed = false;
-    while (batch.size() + mtu_ <= kTunBatchMax) {
-      std::string error;
-      const ReadPacketStatus status = tun_backend_->ReadPacket(mtu_, packet, error);
-      if (status == ReadPacketStatus::Data) {
-        if (!packet.empty()) {
-          AppendTunPacket(batch, packet);
-        }
-        continue;
+    if (!FlushTunBatch(batch, writes_before, batches)) {
+      if (running_.load()) {
+        Fail("SSL write failed in tun-to-device loop");
       }
-      if (status == ReadPacketStatus::NoData) {
-        break;
-      }
-      if (status == ReadPacketStatus::Error && !error.empty()) {
-        tuntap::FwdDebug("forwarder-tun-read-error", "%s", error.c_str());
-      }
-      // Closed or Error: flush drained packets before taking the failure path.
-      read_failed = true;
-      break;
+      return;
     }
-
-    if (!batch.empty()) {
-      if (SslWriteAll(batch.data(), batch.size()) < 0) {
-        if (running_.load()) {
-          Fail("SSL write failed in tun-to-device loop");
-        }
-        return;
-      }
-      ++batches;
-      if (batches <= 100 || batches % 200 == 0) {
-        tuntap::FwdDebug("forwarder-tun-batch", "packets=%llu bytes=%zu batches=%llu",
-                         static_cast<unsigned long long>(tun_writes_.load() - writes_before), batch.size(),
-                         static_cast<unsigned long long>(batches));
-      }
-    }
-
-    if (read_failed) {
+    if (!drain_ok) {
       if (running_.load()) {
         Fail("TUN read failed in tun-to-device loop");
       }

--- a/src/native/tunnel_forwarder.cc
+++ b/src/native/tunnel_forwarder.cc
@@ -26,6 +26,10 @@ namespace {
 constexpr const char* kCdTunnelMagic = "CDTunnel";
 constexpr size_t kCdTunnelHeaderSize = 10;
 constexpr size_t kMaxIngressBuffer = size_t{256} * 1024;
+// Egress batch cap per SSL write. Device-side CDTunnel drops TLS records
+// above ~8.2 KiB (verified on iOS 17 hardware), so writes must stay below
+// that; this also keeps every write to a single record with whole packets.
+constexpr size_t kTunBatchMax = size_t{8192};
 
 #ifdef _WIN32
 constexpr short kPollIn = POLLRDNORM;
@@ -657,8 +661,50 @@ ssize_t TunnelForwarder::WriteTunPacket(const uint8_t* data, size_t len) {
   }
 }
 
+void TunnelForwarder::AppendTunPacket(std::vector<uint8_t>& batch, std::vector<uint8_t>& packet) {
+#ifdef _WIN32
+  if (!IsIpv6Packet(packet.data(), packet.size())) {
+    const uint64_t count = ++tun_drops_;
+    if (count <= 20 || count % 200 == 0) {
+      DebugIpv6Packet("forwarder-tun-drop-nonipv6", packet.data(), packet.size(), count);
+    }
+    return;
+  }
+  if (IsIpv6Multicast(packet.data(), packet.size())) {
+    const uint64_t count = ++tun_drops_;
+    if (count <= 20 || count % 200 == 0) {
+      DebugIpv6Packet("forwarder-tun-drop-mcast", packet.data(), packet.size(), count);
+    }
+    return;
+  }
+  if (IsIcmpv6NeighborDiscovery(packet.data(), packet.size())) {
+    const uint64_t count = ++tun_drops_;
+    if (count <= 20 || count % 200 == 0) {
+      DebugIpv6Packet("forwarder-tun-drop-ndp", packet.data(), packet.size(), count);
+    }
+    return;
+  }
+  uint16_t old_checksum = 0;
+  uint16_t new_checksum = 0;
+  const bool checksum_changed = NormalizeTcpChecksum(packet, old_checksum, new_checksum);
+#endif
+  batch.insert(batch.end(), packet.begin(), packet.end());
+  const uint64_t count = ++tun_writes_;
+  if (count <= 100 || count % 200 == 0) {
+    DebugIpv6Packet("forwarder-tun-write", packet.data(), packet.size(), count);
+#ifdef _WIN32
+    tuntap::FwdDebug("forwarder-tcp-checksum", "packets=%llu changed=%s old=0x%04x new=0x%04x",
+                     static_cast<unsigned long long>(count), checksum_changed ? "true" : "false", old_checksum,
+                     new_checksum);
+#endif
+  }
+}
+
 void TunnelForwarder::TunToDeviceLoop() {
   std::vector<uint8_t> packet;
+  std::vector<uint8_t> batch;
+  batch.reserve(kTunBatchMax);
+  uint64_t batches = 0;
 
   while (running_.load()) {
     const TunReadResult read_result = ReadTunPacket(packet);
@@ -671,46 +717,55 @@ void TunnelForwarder::TunToDeviceLoop() {
     if (read_result != TunReadResult::kOk || packet.empty()) {
       continue;
     }
-#ifdef _WIN32
-    if (!IsIpv6Packet(packet.data(), packet.size())) {
-      const uint64_t count = ++tun_drops_;
-      if (count <= 20 || count % 200 == 0) {
-        DebugIpv6Packet("forwarder-tun-drop-nonipv6", packet.data(), packet.size(), count);
+
+    batch.clear();
+    const uint64_t writes_before = tun_writes_.load();
+    AppendTunPacket(batch, packet);
+
+    // Coalesce packets already queued on the TUN fd into one SSL write.
+    // ReadPacket is used directly: ReadTunPacket turns NoData into a wait.
+    // Stop while a worst-case packet still fits so the write stays one record.
+    bool read_failed = false;
+    while (batch.size() + mtu_ <= kTunBatchMax) {
+      std::string error;
+      const ReadPacketStatus status = tun_backend_->ReadPacket(mtu_, packet, error);
+      if (status == ReadPacketStatus::Data) {
+        if (!packet.empty()) {
+          AppendTunPacket(batch, packet);
+        }
+        continue;
       }
-      continue;
-    }
-    if (IsIpv6Multicast(packet.data(), packet.size())) {
-      const uint64_t count = ++tun_drops_;
-      if (count <= 20 || count % 200 == 0) {
-        DebugIpv6Packet("forwarder-tun-drop-mcast", packet.data(), packet.size(), count);
+      if (status == ReadPacketStatus::NoData) {
+        break;
       }
-      continue;
-    }
-    if (IsIcmpv6NeighborDiscovery(packet.data(), packet.size())) {
-      const uint64_t count = ++tun_drops_;
-      if (count <= 20 || count % 200 == 0) {
-        DebugIpv6Packet("forwarder-tun-drop-ndp", packet.data(), packet.size(), count);
+      if (status == ReadPacketStatus::Error && !error.empty()) {
+        tuntap::FwdDebug("forwarder-tun-read-error", "%s", error.c_str());
       }
-      continue;
+      // Closed or Error: flush drained packets before taking the failure path.
+      read_failed = true;
+      break;
     }
-    uint16_t old_checksum = 0;
-    uint16_t new_checksum = 0;
-    const bool checksum_changed = NormalizeTcpChecksum(packet, old_checksum, new_checksum);
-#endif
-    if (SslWriteAll(packet.data(), packet.size()) < 0) {
+
+    if (!batch.empty()) {
+      if (SslWriteAll(batch.data(), batch.size()) < 0) {
+        if (running_.load()) {
+          Fail("SSL write failed in tun-to-device loop");
+        }
+        return;
+      }
+      ++batches;
+      if (batches <= 100 || batches % 200 == 0) {
+        tuntap::FwdDebug("forwarder-tun-batch", "packets=%llu bytes=%zu batches=%llu",
+                         static_cast<unsigned long long>(tun_writes_.load() - writes_before), batch.size(),
+                         static_cast<unsigned long long>(batches));
+      }
+    }
+
+    if (read_failed) {
       if (running_.load()) {
-        Fail("SSL write failed in tun-to-device loop");
+        Fail("TUN read failed in tun-to-device loop");
       }
       return;
-    }
-    const uint64_t count = ++tun_writes_;
-    if (count <= 100 || count % 200 == 0) {
-      DebugIpv6Packet("forwarder-tun-write", packet.data(), packet.size(), count);
-#ifdef _WIN32
-      tuntap::FwdDebug("forwarder-tcp-checksum", "packets=%llu changed=%s old=0x%04x new=0x%04x",
-                       static_cast<unsigned long long>(count), checksum_changed ? "true" : "false", old_checksum,
-                       new_checksum);
-#endif
     }
   }
 }

--- a/src/native/tunnel_forwarder.h
+++ b/src/native/tunnel_forwarder.h
@@ -60,6 +60,8 @@ class TunnelForwarder {
   void DeviceToTunLoop();
   TunReadResult ReadTunPacket(std::vector<uint8_t>& out);
   void AppendTunPacket(std::vector<uint8_t>& batch, std::vector<uint8_t>& packet);
+  bool DrainQueuedTunPackets(std::vector<uint8_t>& batch, std::vector<uint8_t>& packet);
+  bool FlushTunBatch(const std::vector<uint8_t>& batch, uint64_t writes_before, uint64_t& batches);
   ssize_t WriteTunPacket(const uint8_t* data, size_t len);
   ssize_t SslReadChunk(uint8_t* buf, size_t max_len, bool only_while_running = true);
   void Fail(const std::string& reason);

--- a/src/native/tunnel_forwarder.h
+++ b/src/native/tunnel_forwarder.h
@@ -59,6 +59,7 @@ class TunnelForwarder {
   void TunToDeviceLoop();
   void DeviceToTunLoop();
   TunReadResult ReadTunPacket(std::vector<uint8_t>& out);
+  void AppendTunPacket(std::vector<uint8_t>& batch, std::vector<uint8_t>& packet);
   ssize_t WriteTunPacket(const uint8_t* data, size_t len);
   ssize_t SslReadChunk(uint8_t* buf, size_t max_len, bool only_while_running = true);
   void Fail(const std::string& reason);


### PR DESCRIPTION
## Issue
The tun to device loop sealed and sent every packet as its own TLS record. One lock acquisition, one encryption pass and one write syscall per packet. The lock is shared with the download loop so uploads also serialized against ACK decryption.

## Fix
- Drain packets already queued on the TUN fd into one buffer and send them with a single SSL write
- Batches capped at 8 KiB. The device side CDTunnel drops TLS records above ~8.2 KiB (verified on hardware, same ceiling that broke the MTU 16000 probe in #91). The cap also keeps every write to one record carrying whole packets
- Idle traffic batches to one packet, identical to previous behavior
- New debug line forwarder-tun-batch shows real batch sizes

## Results (iPhone over USB, 10 MiB AFC push)

| Config | Push (5 runs) | Stability 20 rounds | Basic AFC |
|---|---|---|---|
| 1280 before | 26.08 to 26.54 MiB/s | pass, 14.2 s | 4/4 |
| 1280 batching | 26.64 to 28.18 MiB/s | pass, 14.6 s | 4/4 |
| 8000 before | 32.14 to 32.42 MiB/s | pass, 13.8 s | 4/4 |
| 8000 batching | 31.75 to 32.61 MiB/s | pass, 14.1 s | 4/4 |

Native only, no API change.