### PR TITLE
fix: warn once per invalid MTU request value

### DIFF
--- a/src/tunnel/constants.ts
+++ b/src/tunnel/constants.ts
@@ -9,12 +9,14 @@ export const MAX_TUNNEL_MTU_REQUEST_SIZE = 65000;
 export const IPV6_HEADER_SIZE = 40;
 export const IPV6_VERSION = 6;
 
+let warnedInvalidValue: string | null = null;
+
 /**
  * MTU to request in the CDTunnel handshake, from APPIUM_TUNTAP_MTU_REQUEST_SIZE.
  * Clamped to [CD_TUNNEL_MTU_SIZE, MAX_TUNNEL_MTU_REQUEST_SIZE]; unset or invalid
  * falls back to CD_TUNNEL_MTU_SIZE. The device may grant less than requested.
- * Not memoized on purpose: it runs once per tunnel creation and callers may
- * change the env between tunnels (and tests between cases).
+ * Not memoized on purpose: callers may change the env between tunnels; the
+ * invalid-value warning is deduped instead so it logs once per distinct value.
  */
 export function getRequestedTunnelMtu(): number {
   const raw = process.env.APPIUM_TUNTAP_MTU_REQUEST_SIZE?.trim();
@@ -23,7 +25,10 @@ export function getRequestedTunnelMtu(): number {
   }
   const parsed = Number(raw);
   if (!Number.isInteger(parsed)) {
-    log.warn(`Ignoring invalid APPIUM_TUNTAP_MTU_REQUEST_SIZE '${raw}'; using default MTU ${CD_TUNNEL_MTU_SIZE}`);
+    if (warnedInvalidValue !== raw) {
+      warnedInvalidValue = raw;
+      log.warn(`Ignoring invalid APPIUM_TUNTAP_MTU_REQUEST_SIZE '${raw}'; using default MTU ${CD_TUNNEL_MTU_SIZE}`);
+    }
     return CD_TUNNEL_MTU_SIZE;
   }
   return Math.min(Math.max(parsed, CD_TUNNEL_MTU_SIZE), MAX_TUNNEL_MTU_REQUEST_SIZE);


### PR DESCRIPTION
## Issue
The invalid value warning in getRequestedTunnelMtu fired on every tunnel creation. A long running process with a typo in APPIUM_TUNTAP_MTU_REQUEST_SIZE repeated the same warning for every tunnel. Raised in #91 review.

## Fix
Warn once per distinct invalid value. The returned value stays unmemoized so env changes between tunnels and the parametrized tests keep working.